### PR TITLE
Remove beta requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,6 @@ clusters.
 
 1.  Python 2.7+.
 2.  gcloud >= 181.0.0 (2017-11-30)
-    *   gcloud beta components is required. Use `gcloud components install beta`
-        or `sudo apt-get install google-cloud-sdk`.
 3.  Bash 4.0+.
 4.  A GCE project with billing, Google Cloud Dataproc API, Google Compute Engine
     API, and Google Cloud Storage APIs enabled.
@@ -114,7 +112,7 @@ python generate_custom_image.py \
     `projects/<project_id>/global/images/<image_name>`.
 *   **--storage-location**: The storage location (e.g. US, us-central1) of the
     custom GCE image. This flag supports the same
-    [values](https://cloud.google.com/sdk/gcloud/reference/beta/compute/images/create#--storage-location)
+    [values](https://cloud.google.com/sdk/gcloud/reference/compute/images/create#--storage-location)
     as `gcloud compute images create --storage-location` flag. If not specified,
     the default GCE image storage location is used.
 *   **--shutdown-instance-timer-sec**: The time to wait in seconds before

--- a/custom_image_utils/shell_script_generator.py
+++ b/custom_image_utils/shell_script_generator.py
@@ -106,7 +106,7 @@ function main() {{
   fi
 
   echo 'Creating custom image.'
-  gcloud beta compute images create {image_name} \
+  gcloud compute images create {image_name} \
       --project={project_id} \
       --source-disk-zone={zone} \
       --source-disk={image_name}-install \

--- a/custom_image_utils/smoke_test_runner.py
+++ b/custom_image_utils/smoke_test_runner.py
@@ -27,13 +27,8 @@ def _create_workflow_template(workflow_name, image_name, project_id, zone, regio
                               network, subnet):
   """Create a Dataproc workflow template for testing."""
   create_command = [
-<<<<<<< HEAD
       "gcloud", "dataproc", "workflow-templates", "create",
-      workflow_name, "--project", project_id
-=======
-      "gcloud", "beta", "dataproc", "workflow-templates", "create",
       workflow_name, "--project", project_id, "--region", region
->>>>>>> 549340792816de49c8a5bc5f345ec141369ee8a0
   ]
   set_cluster_command = [
       "gcloud", "dataproc", "workflow-templates",
@@ -45,13 +40,8 @@ def _create_workflow_template(workflow_name, image_name, project_id, zone, regio
   else:
     set_cluster_command.extend(["--subnet", subnet])
   add_job_command = [
-<<<<<<< HEAD
       "gcloud", "dataproc", "workflow-templates", "add-job", "spark",
-      "--workflow-template", workflow_name, "--project", project_id,
-=======
-      "gcloud", "beta", "dataproc", "workflow-templates", "add-job", "spark",
       "--workflow-template", workflow_name, "--project", project_id, "--region", region,
->>>>>>> 549340792816de49c8a5bc5f345ec141369ee8a0
       "--step-id", "001", "--class", "org.apache.spark.examples.SparkPi",
       "--jars", "file:///usr/lib/spark/examples/jars/spark-examples.jar", "--",
       "1000"

--- a/custom_image_utils/smoke_test_runner.py
+++ b/custom_image_utils/smoke_test_runner.py
@@ -29,11 +29,11 @@ def _create_workflow_template(workflow_name, image_name, project_id, zone,
   """Create a Dataproc workflow template for testing."""
 
   create_command = [
-      "gcloud", "beta", "dataproc", "workflow-templates", "create",
+      "gcloud", "dataproc", "workflow-templates", "create",
       workflow_name, "--project", project_id
   ]
   set_cluster_command = [
-      "gcloud", "beta", "dataproc", "workflow-templates",
+      "gcloud", "dataproc", "workflow-templates",
       "set-managed-cluster", workflow_name, "--project", project_id, "--image",
       image_name, "--zone", zone
   ]
@@ -42,7 +42,7 @@ def _create_workflow_template(workflow_name, image_name, project_id, zone,
   else:
     set_cluster_command.extend(["--subnet", subnet])
   add_job_command = [
-      "gcloud", "beta", "dataproc", "workflow-templates", "add-job", "spark",
+      "gcloud", "dataproc", "workflow-templates", "add-job", "spark",
       "--workflow-template", workflow_name, "--project", project_id,
       "--step-id", "001", "--class", "org.apache.spark.examples.SparkPi",
       "--jars", "file:///usr/lib/spark/examples/jars/spark-examples.jar", "--",
@@ -71,7 +71,7 @@ def _create_workflow_template(workflow_name, image_name, project_id, zone,
 def _instantiate_workflow_template(workflow_name, project_id):
   """Run a Dataproc workflow template to test the newly built custom image."""
   command = [
-      "gcloud", "beta", "dataproc", "workflow-templates", "instantiate",
+      "gcloud", "dataproc", "workflow-templates", "instantiate",
       workflow_name, "--project", project_id
   ]
   pipe = subprocess.Popen(command)
@@ -83,7 +83,7 @@ def _instantiate_workflow_template(workflow_name, project_id):
 def _delete_workflow_template(workflow_name, project_id):
   """Delete a Dataproc workflow template."""
   command = [
-      "gcloud", "beta", "dataproc", "workflow-templates", "delete",
+      "gcloud", "dataproc", "workflow-templates", "delete",
       workflow_name, "-q", "--project", project_id
   ]
   pipe = subprocess.Popen(command)

--- a/tests/test_shell_script_generator.py
+++ b/tests/test_shell_script_generator.py
@@ -80,7 +80,7 @@ function main() {
   fi
 
   echo 'Creating custom image.'
-  gcloud beta compute images create my-image       --project=my-project       --source-disk-zone=us-west1-a       --source-disk=my-image-install       --storage-location=us-east1       --family=debian9
+  gcloud compute images create my-image       --project=my-project       --source-disk-zone=us-west1-a       --source-disk=my-image-install       --storage-location=us-east1       --family=debian9
   touch /tmp/custom-image-my-image-20190611-160823/image_created
 }
 


### PR DESCRIPTION
This removes the requirement for gcloud "beta" component. Beta is no longer required to run gcloud `compute` or `dataproc` sdk.

I also updated the readme requirements and link to the documentation.