### PR TITLE
Add option for image family URI as source and fix smoke test issue for no external IP option

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,9 +52,11 @@ python generate_custom_image.py \
     customization script will be executed on top of this image instead of an
     out-of-the-box Dataproc image. This image must be a valid Dataproc image.
     **This argument is mutually exclusive with --dataproc-version and --source-image-family.**
-*   **--source-image-family**: The image family that the boot disk will be
-    initialized with. The latest non-deprecated image from the family
-    will be used.
+*   **--base-image-family**: The image family that the boot disk will be
+    initialized with. The latest non-deprecated image from the family will be used.  
+    An example base image family URI is projects/PROJECT_NAME/global/images/family/FAMILY_NAME.  
+    To get the list of image families (and the associated image), run  
+    gcloud compute images list [--project <PROJECT_NAME>]  
     **This argument is mutually exclusive with --dataproc-version and --base-image-uri.**    
 *   **--customization-script**: The script used to install custom packages on
     the image.

--- a/README.md
+++ b/README.md
@@ -47,11 +47,15 @@ python generate_custom_image.py \
     [release notes](https://cloud.google.com/dataproc/docs/release-notes). To
     understand Dataproc versioning, please refer to
     [documentation](https://cloud.google.com/dataproc/docs/concepts/versioning/overview).
-    **This argument is mutually exclusive with --base-image-uri**.
+    **This argument is mutually exclusive with --base-image-uri and --source-image-family**.
 *   **--base-image-uri**: The full image URI for the base Dataproc image. The
     customization script will be executed on top of this image instead of an
     out-of-the-box Dataproc image. This image must be a valid Dataproc image.
-    **This argument is mutually exclusive with --dataproc-version.**
+    **This argument is mutually exclusive with --dataproc-version and --source-image-family.**
+*   **--source-image-family**: The image family that the boot disk will be
+    initialized with. The latest non-deprecated image from the family
+    will be used.
+    **This argument is mutually exclusive with --dataproc-version and --base-image-uri.**    
 *   **--customization-script**: The script used to install custom packages on
     the image.
 *   **--zone**: The GCE zone for running your GCE instance.

--- a/custom_image_utils/args_inferer.py
+++ b/custom_image_utils/args_inferer.py
@@ -88,7 +88,7 @@ def _get_dataproc_image_version(image_uri):
   raise RuntimeError("Cannot find dataproc base image: %s", image_uri)
 
 
-def _get_dataproc_image_family_version(image_family_uri):
+def _get_dataproc_version_from_image_family(image_family_uri):
   """Get Dataproc image family version from family name."""
   project, image_family_name = _extract_image_name_and_project_from_family_uri(image_family_uri)
   command = [
@@ -109,8 +109,8 @@ def _get_dataproc_image_family_version(image_family_uri):
     stdout = temp_file.read()
     # parse the first ready image with the dataproc version attached in labels
     if stdout:
-      parsed_line = stdout.decode('utf-8').strip()  # should be just one value
-      return parsed_line
+      dataproc_version = stdout.decode('utf-8').strip()  # should be just one value
+      return dataproc_version
 
   raise RuntimeError("Cannot find dataproc base image family: %s", image_family_uri)
 
@@ -177,9 +177,9 @@ def _infer_base_image(args):
     args.dataproc_version = _get_dataproc_image_version(args.base_image_uri)
   elif args.dataproc_version:
     args.dataproc_base_image = _get_dataproc_image_path_by_version(args.dataproc_version)
-  elif args.source_image_family_uri:
-    args.dataproc_base_image = _extract_image_family_path(args.source_image_family_uri)
-    args.dataproc_version = _get_dataproc_image_family_version(args.source_image_family_uri)
+  elif args.base_image_family:
+    args.dataproc_base_image = _extract_image_family_path(args.base_image_family)
+    args.dataproc_version = _get_dataproc_version_from_image_family(args.base_image_family)
   else:
     raise RuntimeError(
         "Neither --dataproc-version nor --base-image-uri nor --source-image-family-uri is specified.")

--- a/custom_image_utils/args_parser.py
+++ b/custom_image_utils/args_parser.py
@@ -28,6 +28,7 @@ from custom_image_utils import constants
 # New style images: 1.2.3-deb8, 1.2.3-debian9, 1.2.3-RC10-debian9
 _VERSION_REGEX = re.compile(r"^\d+\.\d+\.\d+(-RC\d+)?(-[a-z]+\d+)?$")
 _FULL_IMAGE_URI = re.compile(r"^(https://www\.googleapis\.com/compute/([^/]+)/)?projects/([^/]+)/global/images/([^/]+)$")
+_FULL_IMAGE_FAMILY_URI = re.compile(r"^(https://www\.googleapis\.com/compute/([^/]+)/)?projects/([^/]+)/global/images/family/([^/]+)$")
 
 
 def _version_regex_type(s):
@@ -41,6 +42,12 @@ def _full_image_uri_regex_type(s):
   if not _FULL_IMAGE_URI.match(s):
     raise argparse.ArgumentTypeError("Invalid image URI: {}.".format(s))
   return s
+
+def _full_image_family_uri_regex_type(s):
+  """Check if the partial image family uri string matches regex."""
+  if not _FULL_IMAGE_FAMILY_URI.match(s):
+    raise argparse.ArgumentTypeError("Invalid image family URI: {}.".format(s))
+  return s  
 
 def parse_args(args):
   """Parses command-line arguments."""
@@ -64,6 +71,11 @@ def parse_args(args):
       an out-of-the-box Dataproc image. This image must be a valid Dataproc
       image.
       """)
+  image_args.add_argument(
+      "--source-image-family-uri",
+      type=_full_image_family_uri_regex_type,
+      help="""The source image family URI. The latest non-depracated image associated with the family will be used.
+      """)      
   required_args.add_argument(
       "--customization-script",
       type=str,

--- a/custom_image_utils/args_parser.py
+++ b/custom_image_utils/args_parser.py
@@ -72,7 +72,7 @@ def parse_args(args):
       image.
       """)
   image_args.add_argument(
-      "--source-image-family-uri",
+      "--base-image-family",
       type=_full_image_family_uri_regex_type,
       help="""The source image family URI. The latest non-depracated image associated with the family will be used.
       """)      

--- a/custom_image_utils/shell_script_generator.py
+++ b/custom_image_utils/shell_script_generator.py
@@ -62,12 +62,19 @@ function main() {{
   done
 
   echo 'Creating disk.'
+  if [ '{source_image_family_uri}' = '' -o  '{source_image_family_uri}' = 'None' ]; then
+     IMAGE_SOURCE="--image={dataproc_base_image}"
+  else
+     IMAGE_SOURCE="--image-family={source_image_family_uri}"
+  fi
+  
   gcloud compute disks create {image_name}-install \
-      --project={project_id} \
-      --zone={zone} \
-      --image={dataproc_base_image} \
-      --type=pd-ssd \
-      --size={disk_size}GB
+    --project={project_id} \
+    --zone={zone} \
+    ${{IMAGE_SOURCE}} \
+    --type=pd-ssd \
+    --size={disk_size}GB
+
   touch "/tmp/{run_id}/disk_created"
 
   echo 'Creating VM instance to run customization script.'

--- a/custom_image_utils/shell_script_generator.py
+++ b/custom_image_utils/shell_script_generator.py
@@ -62,18 +62,18 @@ function main() {{
   done
 
   echo 'Creating disk.'
-  if [ '{source_image_family_uri}' = '' -o  '{source_image_family_uri}' = 'None' ]; then
+  if [[ '{base_image_family}' = '' ||  '{base_image_family}' = 'None' ]]; then
      IMAGE_SOURCE="--image={dataproc_base_image}"
   else
-     IMAGE_SOURCE="--image-family={source_image_family_uri}"
+     IMAGE_SOURCE="--image-family={base_image_family}"
   fi
   
   gcloud compute disks create {image_name}-install \
-    --project={project_id} \
-    --zone={zone} \
-    ${{IMAGE_SOURCE}} \
-    --type=pd-ssd \
-    --size={disk_size}GB
+      --project={project_id} \
+      --zone={zone} \
+      ${{IMAGE_SOURCE}} \
+      --type=pd-ssd \
+      --size={disk_size}GB
 
   touch "/tmp/{run_id}/disk_created"
 

--- a/custom_image_utils/smoke_test_runner.py
+++ b/custom_image_utils/smoke_test_runner.py
@@ -24,7 +24,7 @@ _LOG = logging.getLogger(__name__)
 _LOG.setLevel(logging.INFO)
 
 def _create_workflow_template(workflow_name, image_name, project_id, zone, region,
-                              network, subnet):
+                              network, subnet, no_external_ip):
   """Create a Dataproc workflow template for testing."""
   create_command = [
       "gcloud", "dataproc", "workflow-templates", "create",
@@ -39,6 +39,8 @@ def _create_workflow_template(workflow_name, image_name, project_id, zone, regio
     set_cluster_command.extend(["--network", network])
   else:
     set_cluster_command.extend(["--subnet", subnet])
+  if no_external_ip:
+    set_cluster_command.extend(["--no-address"])
   add_job_command = [
       "gcloud", "dataproc", "workflow-templates", "add-job", "spark",
       "--workflow-template", workflow_name, "--project", project_id, "--region", region,
@@ -90,7 +92,7 @@ def _delete_workflow_template(workflow_name, project_id, region):
     raise RuntimeError("Error deleting workfloe template %s.", workflow_name)
 
 
-def _verify_custom_image(image_name, project_id, zone, network, subnetwork):
+def _verify_custom_image(image_name, project_id, zone, network, subnetwork, no_external_ip):
   """Verifies if custom image works with Dataproc."""
   region = zone[:-2]
   date = datetime.datetime.now().strftime("%Y%m%d%H%M%S")
@@ -101,7 +103,7 @@ def _verify_custom_image(image_name, project_id, zone, network, subnetwork):
     _LOG.info("Creating Dataproc workflow-template %s with image %s...",
               workflow_name, image_name)
     _create_workflow_template(workflow_name, image_name, project_id, zone, region,
-                              network, subnetwork)
+                              network, subnetwork, no_external_ip)
     _LOG.info(
         "Successfully created Dataproc workflow-template %s with image %s...",
         workflow_name, image_name)
@@ -131,7 +133,7 @@ def run(args):
     if not args.no_smoke_test:
       _LOG.info("Verifying the custom image...")
       _verify_custom_image(args.image_name, args.project_id, args.zone,
-                           args.network, args.subnetwork)
+                           args.network, args.subnetwork, args.no_external_ip)
       _LOG.info("Successfully verified the custom image...")
   else:
     _LOG.info("Skip running smoke test (dry run).")

--- a/tests/test_args_parser.py
+++ b/tests/test_args_parser.py
@@ -56,6 +56,7 @@ class TestArgsParser(unittest.TestCase):
         project_id="None",
         service_account="'default'",
         shutdown_instance_timer_sec="300",
+        source_image_family_uri="None",
         storage_location=None,
         subnetwork="''",
         zone="'{}'".format(zone),
@@ -129,6 +130,7 @@ class TestArgsParser(unittest.TestCase):
         project_id="'{}'".format(project_id),
         service_account="'{}'".format(service_account),
         shutdown_instance_timer_sec="{}".format(shutdown_instance_timer_sec),
+        source_image_family_uri="None",
         storage_location="'{}'".format(storage_location),
         subnetwork="'{}'".format(subnetwork),
         zone="'{}'".format(zone),
@@ -156,6 +158,7 @@ class TestArgsParser(unittest.TestCase):
       project_id,
       service_account,
       shutdown_instance_timer_sec,
+      source_image_family_uri,
       storage_location,
       subnetwork,
       zone):
@@ -180,6 +183,7 @@ class TestArgsParser(unittest.TestCase):
         "project_id={}, "
         "service_account={}, "
         "shutdown_instance_timer_sec={}, "
+        "source_image_family_uri={}, "
         "storage_location={}, "
         "subnetwork={}, "
         "zone={})")
@@ -203,6 +207,7 @@ class TestArgsParser(unittest.TestCase):
         project_id,
         service_account,
         shutdown_instance_timer_sec,
+        source_image_family_uri,
         storage_location,
         subnetwork,
         zone)

--- a/tests/test_args_parser.py
+++ b/tests/test_args_parser.py
@@ -39,6 +39,7 @@ class TestArgsParser(unittest.TestCase):
 
     expected_result = self._make_expected_result(
         accelerator=None,
+        base_image_family="None",
         base_image_uri="None",
         customization_script="'{}'".format(customization_script),
         dataproc_version="None",
@@ -56,7 +57,6 @@ class TestArgsParser(unittest.TestCase):
         project_id="None",
         service_account="'default'",
         shutdown_instance_timer_sec="300",
-        source_image_family_uri="None",
         storage_location=None,
         subnetwork="''",
         zone="'{}'".format(zone),
@@ -112,6 +112,7 @@ class TestArgsParser(unittest.TestCase):
 
     expected_result = self._make_expected_result(
         accelerator="'{}'".format(accelerator),
+        base_image_family="None",        
         base_image_uri="None",
         customization_script="'{}'".format(customization_script),
         dataproc_version="'{}'".format(dataproc_version),
@@ -130,7 +131,6 @@ class TestArgsParser(unittest.TestCase):
         project_id="'{}'".format(project_id),
         service_account="'{}'".format(service_account),
         shutdown_instance_timer_sec="{}".format(shutdown_instance_timer_sec),
-        source_image_family_uri="None",
         storage_location="'{}'".format(storage_location),
         subnetwork="'{}'".format(subnetwork),
         zone="'{}'".format(zone),
@@ -140,6 +140,7 @@ class TestArgsParser(unittest.TestCase):
   def _make_expected_result(
       self,
       accelerator,
+      base_image_family,      
       base_image_uri,
       customization_script,
       dataproc_version,
@@ -158,13 +159,13 @@ class TestArgsParser(unittest.TestCase):
       project_id,
       service_account,
       shutdown_instance_timer_sec,
-      source_image_family_uri,
       storage_location,
       subnetwork,
       zone):
     expected_result_template = (
         "Namespace("
         "accelerator={}, "
+        "base_image_family={}, "        
         "base_image_uri={}, "
         "customization_script={}, "
         "dataproc_version={}, "
@@ -183,12 +184,12 @@ class TestArgsParser(unittest.TestCase):
         "project_id={}, "
         "service_account={}, "
         "shutdown_instance_timer_sec={}, "
-        "source_image_family_uri={}, "
         "storage_location={}, "
         "subnetwork={}, "
         "zone={})")
     return expected_result_template.format(
         accelerator,
+        base_image_family,        
         base_image_uri,
         customization_script,
         dataproc_version,
@@ -207,7 +208,6 @@ class TestArgsParser(unittest.TestCase):
         project_id,
         service_account,
         shutdown_instance_timer_sec,
-        source_image_family_uri,
         storage_location,
         subnetwork,
         zone)

--- a/tests/test_shell_script_generator.py
+++ b/tests/test_shell_script_generator.py
@@ -59,13 +59,13 @@ function main() {
   done
 
   echo 'Creating disk.'
-  if [ 'projects/my-dataproc-project/global/images/family/debian-10' = '' -o  'projects/my-dataproc-project/global/images/family/debian-10' = 'None' ]; then
+  if [[ 'projects/my-dataproc-project/global/images/family/debian-10' = '' ||  'projects/my-dataproc-project/global/images/family/debian-10' = 'None' ]]; then
      IMAGE_SOURCE="--image=projects/cloud-dataproc/global/images/dataproc-1-4-deb9-20190510-000000-rc01"
   else
      IMAGE_SOURCE="--image-family=projects/my-dataproc-project/global/images/family/debian-10"
   fi
   
-  gcloud compute disks create my-image-install     --project=my-project     --zone=us-west1-a     ${IMAGE_SOURCE}     --type=pd-ssd     --size=40GB
+  gcloud compute disks create my-image-install       --project=my-project       --zone=us-west1-a       ${IMAGE_SOURCE}       --type=pd-ssd       --size=40GB
 
   touch "/tmp/custom-image-my-image-20190611-160823/disk_created"
 
@@ -122,7 +122,7 @@ class TestShellScriptGenerator(unittest.TestCase):
         'project_id': 'my-project',
         'storage_location': 'us-east1',
         'shutdown_timer_in_sec': 500,
-        'source_image_family_uri': 'projects/my-dataproc-project/global/images/family/debian-10'
+        'base_image_family': 'projects/my-dataproc-project/global/images/family/debian-10'
     }
 
     script = shell_script_generator.Generator().generate(args)

--- a/tests/test_shell_script_generator.py
+++ b/tests/test_shell_script_generator.py
@@ -59,7 +59,14 @@ function main() {
   done
 
   echo 'Creating disk.'
-  gcloud compute disks create my-image-install       --project=my-project       --zone=us-west1-a       --image=projects/cloud-dataproc/global/images/dataproc-1-4-deb9-20190510-000000-rc01       --type=pd-ssd       --size=40GB
+  if [ 'projects/my-dataproc-project/global/images/family/debian-10' = '' -o  'projects/my-dataproc-project/global/images/family/debian-10' = 'None' ]; then
+     IMAGE_SOURCE="--image=projects/cloud-dataproc/global/images/dataproc-1-4-deb9-20190510-000000-rc01"
+  else
+     IMAGE_SOURCE="--image-family=projects/my-dataproc-project/global/images/family/debian-10"
+  fi
+  
+  gcloud compute disks create my-image-install     --project=my-project     --zone=us-west1-a     ${IMAGE_SOURCE}     --type=pd-ssd     --size=40GB
+
   touch "/tmp/custom-image-my-image-20190611-160823/disk_created"
 
   echo 'Creating VM instance to run customization script.'
@@ -114,7 +121,8 @@ class TestShellScriptGenerator(unittest.TestCase):
         'oauth': '',
         'project_id': 'my-project',
         'storage_location': 'us-east1',
-        'shutdown_timer_in_sec': 500
+        'shutdown_timer_in_sec': 500,
+        'source_image_family_uri': 'projects/my-dataproc-project/global/images/family/debian-10'
     }
 
     script = shell_script_generator.Generator().generate(args)


### PR DESCRIPTION
New parameter added to use an image family URI as the source. Also, fixed an issue with the smoke test, which would break when the --no-external-ip option was used.