### PR TITLE
Remove auth keys and customization scripts from the new image

### DIFF
--- a/startup_script/run.sh
+++ b/startup_script/run.sh
@@ -78,11 +78,23 @@ function run_custom_script() {
   fi
 }
 
+function cleanup() {
+  # .config and .gsutil dirs are created by the gsutil command. It contains
+  # transient authentication keys to access gcs bucket. The init_actions.sh and
+  # run.sh are your customization and bootstrap scripts (this) which must be
+  # removed after creating the image
+  rm -rf ~/.config/
+  rm -rf ~/.gsutil/
+  rm ./init_actions.sh
+  rm ./run.sh
+}
+
 function main() {
   wait_until_ready
 
   if [[ "${ready}" == "true" ]]; then
     run_custom_script
+    cleanup
   fi
 
   echo "Sleep ${SHUTDOWN_TIMER_IN_SEC}s before shutting down..."

--- a/startup_script/run.sh
+++ b/startup_script/run.sh
@@ -83,10 +83,8 @@ function cleanup() {
   # transient authentication keys to access gcs bucket. The init_actions.sh and
   # run.sh are your customization and bootstrap scripts (this) which must be
   # removed after creating the image
-  rm -rf ~/.config/
-  rm -rf ~/.gsutil/
-  rm ./init_actions.sh
-  rm ./run.sh
+  rm -rf ~/.config/ ~/.gsutil/
+  rm ./init_actions.sh ./run.sh
 }
 
 function main() {


### PR DESCRIPTION
.config and .gsutil dirs are created by the gsutil command. It contains
transient authentication keys to access gcs bucket. The init_actions.sh and
run.sh are your customization and bootstrap scripts (this) which must be
removed after creating the image