### PR TITLE
[custom-images] allowing rocky but no longer centos for image versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,23 @@
 # since this script depends on python 2.7, we need a stable base from which to run it
 FROM python:2.7-slim
 
+# To build: docker build -t dataproc-custom-images:latest .
+# To run: docker run -it dataproc-custom-images:latest /bin/bash
+
+# and then from the docker bash shell, run the
+# generate_custom_image.py as per examples/secure-boot/README.md
+
+# python generate_custom_image.py \
+#     --image-name ${image_name} \
+#     --dataproc-version ${dataproc_version} \
+#     --trusted-cert "tls/db.der" \
+#     --customization-script ${customization_script} \
+#     --metadata "${metadata}" \
+#     --zone "${custom_image_zone}" \
+#     --disk-size "${disk_size_gb}" \
+#     --no-smoke-test \
+#     --gcs-bucket "${my_bucket}"
+
 WORKDIR /custom-images
 
 RUN apt-get update && apt-get -y install apt-transport-https ca-certificates gnupg curl

--- a/custom_image_utils/args_parser.py
+++ b/custom_image_utils/args_parser.py
@@ -29,7 +29,7 @@ from custom_image_utils import constants
 _VERSION_REGEX = re.compile(r"^\d+\.\d+\.\d+(-RC\d+)?(-[a-z]+\d+)?$")
 _FULL_IMAGE_URI = re.compile(r"^(https://www\.googleapis\.com/compute/([^/]+)/)?projects/([^/]+)/global/images/([^/]+)$")
 _FULL_IMAGE_FAMILY_URI = re.compile(r"^(https://www\.googleapis\.com/compute/([^/]+)/)?projects/([^/]+)/global/images/family/([^/]+)$")
-_LATEST_FROM_MINOR_VERSION = re.compile(r"^(\d+)\.(\d+)-((?:debian|ubuntu|centos)\d+)$")
+_LATEST_FROM_MINOR_VERSION = re.compile(r"^(\d+)\.(\d+)-((?:debian|ubuntu|rocky)\d+)$")
 
 def _version_regex_type(s):
   """Check if version string matches regex."""

--- a/examples/secure-boot/README.md
+++ b/examples/secure-boot/README.md
@@ -29,12 +29,14 @@ metadata="${metadata},private_secret_name=${private_secret_name}"
 metadata="${metadata},secret_project=${secret_project}"
 metadata="${metadata},secret_version=${secret_version}"
 
-#dataproc_version=2.1-debian11
+#dataproc_version=2.2-rocky9
+#dataproc_version=2.2-ubuntu22
 dataproc_version=2.2-debian12
 #customization_script=examples/secure-boot/install-nvidia-driver-debian11.sh
 customization_script=examples/secure-boot/install-nvidia-driver-debian12.sh
-#image_name="nvidia-open-kernel-bullseye-$(date +%F)"
-image_name="nvidia-open-kernel-bookworm-$(date +%F)"
+#image_name="nvidia-open-kernel-2.2-ubuntu22-$(date +%F)"
+#image_name="nvidia-open-kernel-2.2-rocky9-$(date +%F)"
+image_name="nvidia-open-kernel-2.2-debian12-$(date +%F)"
 disk_size_gb="50"
 
 python generate_custom_image.py \


### PR DESCRIPTION
We should have changed this long ago.  Better late than never.