### PR TITLE
Reduce img clone 20241014

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.
 
 RUN apt-get -y -qq update && apt-get -y -qq install google-cloud-cli && apt-get clean
 
-RUN apt-get -y -qq install emacs-nox vim && apt-get clean
+RUN apt-get -y -qq install emacs-nox vim libmime-base64-perl && apt-get clean
 
 COPY . ${WORKDIR}
 

--- a/examples/secure-boot/build-current-images.sh
+++ b/examples/secure-boot/build-current-images.sh
@@ -88,7 +88,7 @@ session_name="build-current-images"
 screen -US "${session_name}" -c examples/secure-boot/pre-init.screenrc
 
 # tail -n 3 /tmp/custom-image-cuda-pre-init-2-*/logs/workflow.log
-# grep -A6 'Filesystem.*Avail' /tmp/custom-image-cuda-pre-init-2-*/logs/startup-script.log | perl -ne 'print $1,$/ if( m:( Filesystem.* Avail.*| /dev/.*/\s*$|^--): )'
+# grep -A6 'Filesystem.*Avail' /tmp/custom-image-cuda-pre-init-2-*/logs/startup-script.log | perl -ne 'print if( /Avail/ or m:/\s*$: or /^-/ )'
 
 revoke_bindings
 

--- a/examples/secure-boot/build-current-images.sh
+++ b/examples/secure-boot/build-current-images.sh
@@ -88,7 +88,7 @@ session_name="build-current-images"
 screen -US "${session_name}" -c examples/secure-boot/pre-init.screenrc
 
 # tail -n 3 /tmp/custom-image-cuda-pre-init-2-*/logs/workflow.log
-# grep -A6 'Filesystem.*Avail' /tmp/custom-image-cuda-pre-init-2-*/logs/startup-script.log | perl -ne 'print if( /Avail/ or m:/\s*$: or /^-/ )'
+# grep -A6 'Filesystem.*Avail' /tmp/custom-image-cuda-pre-init-2-*/logs/startup-script.log | perl -ne 'print $1,$/ if( m:( Filesystem.* Avail.*| /dev/.*/\s*$|^--): )'
 
 revoke_bindings
 

--- a/examples/secure-boot/pre-init.screenrc
+++ b/examples/secure-boot/pre-init.screenrc
@@ -4,14 +4,14 @@
 
 # screen -L -t monitor 0 /bin/bash
 
-screen -L -t 2.2-debian12 1 /bin/bash -x examples/secure-boot/pre-init.sh 2.2-debian12 examples/secure-boot/install_gpu_driver.sh
-screen -L -t 2.1-debian11 2 /bin/bash -x examples/secure-boot/pre-init.sh 2.1-debian11 examples/secure-boot/install_gpu_driver.sh
-screen -L -t 2.0-debian10 3 /bin/bash -x examples/secure-boot/pre-init.sh 2.0-debian10 examples/secure-boot/install_gpu_driver.sh
+screen -L -t 2.2-debian12 1 /bin/bash -x examples/secure-boot/pre-init.sh 2.2-debian12
+screen -L -t 2.1-debian11 2 /bin/bash -x examples/secure-boot/pre-init.sh 2.1-debian11
+screen -L -t 2.0-debian10 3 /bin/bash -x examples/secure-boot/pre-init.sh 2.0-debian10
 
-screen -L -t 2.2-ubuntu22 4 /bin/bash -x examples/secure-boot/pre-init.sh 2.2-ubuntu22 examples/secure-boot/install_gpu_driver.sh
-screen -L -t 2.1-ubuntu20 5 /bin/bash -x examples/secure-boot/pre-init.sh 2.1-ubuntu20 examples/secure-boot/install_gpu_driver.sh
-screen -L -t 2.0-ubuntu18 6 /bin/bash -x examples/secure-boot/pre-init.sh 2.0-ubuntu18 examples/secure-boot/install_gpu_driver.sh
+screen -L -t 2.2-ubuntu22 4 /bin/bash -x examples/secure-boot/pre-init.sh 2.2-ubuntu22
+screen -L -t 2.1-ubuntu20 5 /bin/bash -x examples/secure-boot/pre-init.sh 2.1-ubuntu20
+screen -L -t 2.0-ubuntu18 6 /bin/bash -x examples/secure-boot/pre-init.sh 2.0-ubuntu18
 
-screen -L -t 2.2-rocky9   7 /bin/bash -x examples/secure-boot/pre-init.sh 2.2-rocky9   examples/secure-boot/install_gpu_driver.sh
-screen -L -t 2.1-rocky8   8 /bin/bash -x examples/secure-boot/pre-init.sh 2.1-rocky8   examples/secure-boot/install_gpu_driver.sh
-screen -L -t 2.0-rocky8   9 /bin/bash -x examples/secure-boot/pre-init.sh 2.0-rocky8   examples/secure-boot/install_gpu_driver.sh
+screen -L -t 2.2-rocky9   7 /bin/bash -x examples/secure-boot/pre-init.sh 2.2-rocky9
+screen -L -t 2.1-rocky8   8 /bin/bash -x examples/secure-boot/pre-init.sh 2.1-rocky8
+screen -L -t 2.0-rocky8   9 /bin/bash -x examples/secure-boot/pre-init.sh 2.0-rocky8

--- a/examples/secure-boot/pre-init.sh
+++ b/examples/secure-boot/pre-init.sh
@@ -14,17 +14,18 @@
 #
 # This script creates a custom image with the script specified loaded
 #
-# pre-init.sh <dataproc version> <customization script>
+# pre-init.sh <dataproc version>
 
 set -e
+readonly timestamp="$(date +%F-%H-%M)"
 
 IMAGE_VERSION="$1"
 if [[ -z "${IMAGE_VERSION}" ]] ; then
-export IMAGE_VERSION="$(jq -r .IMAGE_VERSION env.json)" ; fi
-export PROJECT_ID="$(jq    -r .PROJECT_ID    env.json)"
-export PURPOSE="$(jq       -r .PURPOSE       env.json)"
-export BUCKET="$(jq        -r .BUCKET        env.json)"
-export ZONE="$(jq          -r .ZONE          env.json)"
+export IMAGE_VERSION="$(jq -r .IMAGE_VERSION        env.json)" ; fi
+export PROJECT_ID="$(jq    -r .PROJECT_ID           env.json)"
+export PURPOSE="$(jq       -r .PURPOSE              env.json)"
+export BUCKET="$(jq        -r .BUCKET               env.json)"
+export ZONE="$(jq          -r .ZONE                 env.json)"
 
 custom_image_zone="${ZONE}"
 disk_size_gb="30" # greater than or equal to 30
@@ -41,6 +42,9 @@ metadata="public_secret_name=${public_secret_name}"
 metadata="${metadata},private_secret_name=${private_secret_name}"
 metadata="${metadata},secret_project=${secret_project}"
 metadata="${metadata},secret_version=${secret_version}"
+metadata="${metadata},dask-runtime=yarn"
+metadata="${metadata},rapids-runtime=SPARK"
+metadata="${metadata},cuda-version=12.4"
 
 # If no OS family specified, default to debian
 if [[ "${IMAGE_VERSION}" != *-* ]] ; then
@@ -53,36 +57,91 @@ else
   dataproc_version="${IMAGE_VERSION}"
 fi
 
+# base image -> cuda
+# case "${dataproc_version}" in
+#   "2.2-rocky9"   ) disk_size_gb="54" ;;
+#   "2.1-rocky8"   ) disk_size_gb="36" ;;
+#   "2.0-rocky8"   ) disk_size_gb="33" ;;
+#   "2.2-ubuntu22" ) disk_size_gb="40" ;;
+#   "2.1-ubuntu20" ) disk_size_gb="37" ;;
+#   "2.0-ubuntu18" ) disk_size_gb="37" ;;
+#   "2.2-debian12" ) disk_size_gb="40" ;;
+#   "2.1-debian11" ) disk_size_gb="40" ;;
+#   "2.0-debian10" ) disk_size_gb="40" ;;
+# esac
+
+# cuda image -> dask
+# case "${dataproc_version}" in
+#   "2.2-rocky9"   ) disk_size_gb="54" ;;
+#   "2.1-rocky8"   ) disk_size_gb="37" ;;
+#   "2.0-rocky8"   ) disk_size_gb="40" ;;
+#   "2.2-ubuntu22" ) disk_size_gb="45" ;;
+#   "2.1-ubuntu20" ) disk_size_gb="42" ;;
+#   "2.0-ubuntu18" ) disk_size_gb="37" ;;
+#   "2.2-debian12" ) disk_size_gb="46" ;;
+#   "2.1-debian11" ) disk_size_gb="40" ;;
+#   "2.0-debian10" ) disk_size_gb="40" ;;
+# esac
+
+# dask image -> rapids
 case "${dataproc_version}" in
   "2.2-rocky9"   ) disk_size_gb="54" ;;
-  "2.1-rocky8"   ) disk_size_gb="36" ;;
-  "2.0-rocky8"   ) disk_size_gb="33" ;;
-  "2.2-ubuntu22" ) disk_size_gb="40" ;;
-  "2.1-ubuntu20" ) disk_size_gb="37" ;;
+  "2.1-rocky8"   ) disk_size_gb="37" ;;
+  "2.0-rocky8"   ) disk_size_gb="40" ;;
+  "2.2-ubuntu22" ) disk_size_gb="45" ;;
+  "2.1-ubuntu20" ) disk_size_gb="42" ;;
   "2.0-ubuntu18" ) disk_size_gb="37" ;;
-  "2.2-debian12" ) disk_size_gb="40" ;;
+  "2.2-debian12" ) disk_size_gb="46" ;;
   "2.1-debian11" ) disk_size_gb="40" ;;
   "2.0-debian10" ) disk_size_gb="40" ;;
 esac
 
-echo "#!/bin/bash\necho no op" | dd of=empty.sh status=none
-customization_script="${2:-empty.sh}"
 
-image_name="${PURPOSE}-${dataproc_version/\./-}-$(date +%F-%H-%M)"
-
-set -x +e
-python generate_custom_image.py \
-    --machine-type         "n1-highcpu-4" \
+function generate() {
+  local extra_args="$*"
+  set -x
+  python generate_custom_image.py \
+    --machine-type         "n1-standard-4" \
     --accelerator          "type=nvidia-tesla-t4" \
-    --image-name           "${image_name}" \
-    --dataproc-version     "${dataproc_version}" \
-    --trusted-cert         "tls/db.der" \
+    --image-name           "${PURPOSE}-${dataproc_version/\./-}-${timestamp}" \
     --customization-script "${customization_script}" \
     --service-account      "${GSA}" \
     --metadata             "${metadata}" \
     --zone                 "${custom_image_zone}" \
     --disk-size            "${disk_size_gb}" \
-    --no-smoke-test \
     --gcs-bucket           "${BUCKET}" \
-    --shutdown-instance-timer-sec=300
-set +x
+    --shutdown-instance-timer-sec=30 \
+    --no-smoke-test \
+    ${extra_args}
+  set +x
+}
+
+function generate_from_dataproc_version() {
+  local dataproc_version="$1"
+  generate --dataproc-version "${dataproc_version}"
+}
+
+function generate_from_base_purpose() {
+  local base_purpose="$1"
+  generate --base-image-uri "https://www.googleapis.com/compute/v1/projects/${PROJECT_ID}/global/images/${base_purpose}-${dataproc_version/\./-}-${timestamp}"
+}
+
+# Install GPU drivers + cuda on dataproc base image
+PURPOSE="cuda-pre-init"
+customization_script="examples/secure-boot/install_gpu_driver.sh"
+
+time generate_from_dataproc_version "${dataproc_version}"
+
+# Install dask on cuda base image
+base_purpose="${PURPOSE}"
+PURPOSE="dask-pre-init"
+customization_script="examples/secure-boot/dask.sh"
+
+time generate_from_base_purpose "${base_purpose}"
+
+# Install rapids on dask base image
+base_purpose="${PURPOSE}"
+PURPOSE="rapids-pre-init"
+customization_script="examples/secure-boot/rapids.sh"
+
+time generate_from_base_purpose "${base_purpose}"


### PR DESCRIPTION
* Check base image description JSON to determine whether certs from
  our trust database are already included  

* Logic to do the above depends on libmime-base64-perl, so add it to
  the Dockerfile

* Create convenience functions to extract certificates from image
  description, compute modulus md5sum from these certificates, and to
  test whether an element is in a bash array

* no longer use `--source-image-family={base_image_family}` if passed.
  Instead, compute `--source-image={dataproc_base_image}` and use it
  in all use cases

* If the base image has certificates, compare the certificates we plan
  to install with the ones already installed.  If the base image
  already includes our certificates, use the base image to boot the
  new instance

* If the base image has certificates, but does not include the ones we
  intend to install, include these certificates after our entries

* If the user specifies an empty string for the trusted cert, fall
  back to previous logic of creating a disk from the base image.
