### PR TITLE
Add missing semicolon to shell_script_generator.py (#99)

### DIFF
--- a/custom_image_utils/shell_script_generator.py
+++ b/custom_image_utils/shell_script_generator.py
@@ -154,7 +154,7 @@ function main() {{
 
   date
   set -x
-  if [[ -z "${{cert_args}}" && "${{num_src_certs}}" -ne "0" ]] then
+  if [[ -z "${{cert_args}}" && "${{num_src_certs}}" -ne "0" ]]; then
     echo 'Re-using base image'
     base_obj_type="reuse"
     instance_disk_args='--image-project={project_id} --image={dataproc_base_image} --boot-disk-size={disk_size}G --boot-disk-type=pd-ssd'


### PR DESCRIPTION
Hi, 

as @igor-susic mentioned in #99, there is missing semicolon in the [shell_script_generator.py](https://github.com/GoogleCloudDataproc/custom-images/blob/main/custom_image_utils/shell_script_generator.py#L157). This change fixes it.

