### PR TITLE
[rapids] Test dask rapids

### DIFF
--- a/custom_image_utils/shell_script_generator.py
+++ b/custom_image_utils/shell_script_generator.py
@@ -110,6 +110,7 @@ function main() {{
   done
 
   local cert_args=""
+  local num_src_certs="0"
   if [[ -n '{trusted_cert}' ]] && [[ -f '{trusted_cert}' ]]; then
     # build tls/ directory from variables defined near the header of
     # the examples/secure-boot/create-key-pair.sh file
@@ -135,9 +136,9 @@ function main() {{
     local -a src_img_modulus_md5sums=()
 
     mapfile -t src_img_modulus_md5sums < <(print_img_dbs_modulus_md5sums {dataproc_base_image})
-    local num_src_certs="${{#src_img_modulus_md5sums[@]}}"
+    num_src_certs="${{#src_img_modulus_md5sums[@]}}"
     echo "${{num_src_certs}} db certificates attached to source image"
-    if [[ ${{num_src_certs}} -eq 0 ]]; then
+    if [[ "${{num_src_certs}}" -eq "0" ]]; then
       echo "no db certificates in source image"
       cert_list=default_cert_list
     else

--- a/custom_image_utils/shell_script_generator.py
+++ b/custom_image_utils/shell_script_generator.py
@@ -216,7 +216,7 @@ function main() {{
       --port=1 2>&1 \
       | grep 'startup-script' \
       | sed -e 's/ {image_name}-install.*startup-script://g' \
-      | dd bs=64 of={log_dir}/startup-script.log \
+      | dd bs=1 of={log_dir}/startup-script.log \
       || true
   echo 'Checking customization script result.'
   date

--- a/examples/secure-boot/README.md
+++ b/examples/secure-boot/README.md
@@ -52,8 +52,8 @@ in the file examples/secure-boot/env.json.sample.
 ```bash
 cp examples/secure-boot/env.json.sample env.json
 vi env.json
-docker build -t dataproc-custom-images:latest .
-docker run -it dataproc-custom-images:latest /bin/bash examples/secure-boot/cuda.sh
+docker build -t dataproc-cuda-pre-init:latest .
+docker run -it dataproc-cuda-pre-init:latest /bin/bash examples/secure-boot/cuda.sh
 ```
 
 To do the same, but for all dataproc variants including supported
@@ -64,6 +64,6 @@ script can be run in docker:
 ```bash
 cp examples/secure-boot/env.json.sample env.json
 vi env.json
-docker build -t dataproc-custom-images:latest .
-docker run -it dataproc-custom-images:latest /bin/bash examples/secure-boot/build-current-images.sh
+docker build -t dataproc-dask-rapids-pre-init:latest .
+docker run -it dataproc-dask-rapids-pre-init:latest /bin/bash examples/secure-boot/build-current-images.sh
 ```

--- a/examples/secure-boot/build-current-images.sh
+++ b/examples/secure-boot/build-current-images.sh
@@ -15,7 +15,7 @@
 #
 # This script creates a custom image pre-loaded with cuda
 
-set -e
+set -ex
 
 function configure_service_account() {
   # Create service account
@@ -87,8 +87,17 @@ session_name="build-current-images"
 # Run all image generation scripts simultaneously
 screen -US "${session_name}" -c examples/secure-boot/pre-init.screenrc
 
-# tail -n 3 /tmp/custom-image-cuda-pre-init-2-*/logs/workflow.log
-# grep -A6 'Filesystem.*Avail' /tmp/custom-image-cuda-pre-init-2-*/logs/startup-script.log | perl -ne 'print $1,$/ if( m:( Filesystem.* Avail.*| /dev/.*/\s*$|^--): )'
+# tail -n 3 /tmp/custom-image-*/logs/workflow.log
+# tail -n 3 /tmp/custom-image-${PURPOSE}-2-*/logs/workflow.log
+function find_disk_usage() {
+  for f in /tmp/custom-*/logs/startup*.log
+  do
+    echo $f
+    grep -A6 'Filesystem.*Avail' $f \
+      | perl -ne 'print $1,$/ if( m:( File.* Avail.*| /dev/.*/\s*$): )'
+  done
+}
+# grep 'Customization script' /tmp/custom-image-*/logs/workflow.log
 
 revoke_bindings
 
@@ -106,3 +115,37 @@ revoke_bindings
 #  /dev/sda1        40G   37G  1.1G  98% / # 2.2-debian12
 #  /dev/sda2        54G   34G   21G  63% / # 2.2-rocky9
 #  /dev/root        39G   37G  2.4G  94% / # 2.2-ubuntu22
+
+#
+# disk size - 20241021
+#
+ Filesystem      Size  Used Avail Use% Mounted on
+ /dev/sda1        40G   29G  9.1G  76% / # cuda-pre-init-2-0-debian10
+ /dev/sda2        33G   30G  3.4G  90% / # cuda-pre-init-2-0-rocky8
+ /dev/sda1        36G   29G  7.0G  81% / # cuda-pre-init-2-0-ubuntu18
+ /dev/sda1        40G   35G  2.7G  93% / # cuda-pre-init-2-1-debian11
+ /dev/sda2        36G   33G  3.3G  91% / # cuda-pre-init-2-1-rocky8
+ /dev/root        36G   34G  2.1G  95% / # cuda-pre-init-2-1-ubuntu20
+ /dev/sda1        40G   37G  1.1G  98% / # cuda-pre-init-2-2-debian12
+ /dev/sda2        54G   34G   20G  63% / # cuda-pre-init-2-2-rocky9
+ /dev/root        39G   37G  2.4G  94% / # cuda-pre-init-2-2-ubuntu22
+
+ /dev/sda1        40G   32G  6.4G  83% / # dask-pre-init-2-0-debian10
+ /dev/sda2        65G   33G   33G  51% / # dask-pre-init-2-0-rocky8
+ /dev/sda1        36G   32G  4.3G  89% / # dask-pre-init-2-0-ubuntu18
+ /dev/sda1        40G   38G  111M 100% / # dask-pre-init-2-1-debian11
+ /dev/sda2        37G   36G  1.7G  96% / # dask-pre-init-2-1-rocky8
+ /dev/root        41G   37G  4.3G  90% / # dask-pre-init-2-1-ubuntu20
+ /dev/sda1        46G   39G  4.4G  90% / # dask-pre-init-2-2-debian12
+ /dev/sda2        54G   37G   18G  68% / # dask-pre-init-2-2-rocky9
+ /dev/root        44G   39G  4.9G  89% / # dask-pre-init-2-2-ubuntu22
+
+ /dev/sda1        64G   49G   13G  80% / # rapids-pre-init-2-0-debian10
+ /dev/sda2        65G   50G   15G  78% / # rapids-pre-init-2-0-rocky8
+ /dev/sda1        63G   49G   14G  78% / # rapids-pre-init-2-0-ubuntu18
+ /dev/sda1        64G   55G  6.2G  90% / # rapids-pre-init-2-1-debian11
+ /dev/sda2        65G   53G   12G  82% / # rapids-pre-init-2-1-rocky8
+ /dev/root        63G   54G  9.1G  86% / # rapids-pre-init-2-1-ubuntu20
+ /dev/sda1        64G   56G  5.2G  92% / # rapids-pre-init-2-2-debian12
+ /dev/sda2        65G   54G   12G  83% / # rapids-pre-init-2-2-rocky9
+ /dev/root        63G   56G  7.1G  89% / # rapids-pre-init-2-2-ubuntu22

--- a/examples/secure-boot/dask.sh
+++ b/examples/secure-boot/dask.sh
@@ -463,7 +463,7 @@ function install_dask() {
       time "${installer}" "create" -m -n "dask" -y --no-channel-priority \
       -c 'conda-forge' -c 'nvidia'  \
       ${CONDA_PACKAGES[*]} \
-      "${python_spec}"
+      "${python_spec}" > /dev/null 2>&1
     local retval=$?
     sync
     if [[ "$retval" == "0" ]] ; then

--- a/examples/secure-boot/dask.sh
+++ b/examples/secure-boot/dask.sh
@@ -22,10 +22,10 @@
 set -euxo pipefail
 
 function os_id()       { grep '^ID=' /etc/os-release | cut -d= -f2 | xargs ; }
-function os_version()  { grep '^VERSION_ID=' /etc/os-release | cut -d= -f2 | xargs ; }
-function os_codename() { grep '^VERSION_CODENAME=' /etc/os-release | cut -d= -f2 | xargs ; }
 function is_ubuntu()   { [[ "$(os_id)" == 'ubuntu' ]] ; }
 function is_ubuntu18() { is_ubuntu && [[ "$(os_version)" == '18.04'* ]] ; }
+function is_debian()   { [[ "$(os_id)" == 'debian' ]] ; }
+function is_debuntu()  { is_debian || is_ubuntu ; }
 
 function print_metadata_value() {
   local readonly tmpfile=$(mktemp)
@@ -64,52 +64,34 @@ function get_metadata_value() {
   return ${return_code}
 }
 
-function get_metadata_attribute() {
+function get_metadata_attribute() (
   set +x
   local -r attribute_name="$1"
   local -r default_value="${2:-}"
   get_metadata_value "attributes/${attribute_name}" || echo -n "${default_value}"
-  set -x
-}
+)
 
-readonly DEFAULT_CUDA_VERSION="12.4"
-readonly CUDA_VERSION=$(get_metadata_attribute 'cuda-version' ${DEFAULT_CUDA_VERSION})
 function is_cuda12() { [[ "${CUDA_VERSION%%.*}" == "12" ]] ; }
 function is_cuda11() { [[ "${CUDA_VERSION%%.*}" == "11" ]] ; }
 
-readonly DASK_RUNTIME="$(get_metadata_attribute dask-runtime || echo 'standalone')"
-
-# Dask 'standalone' config
-readonly DASK_SERVICE=dask-cluster
-readonly DASK_WORKER_SERVICE=dask-worker
-readonly DASK_SCHEDULER_SERVICE=dask-scheduler
-
-readonly KNOX_HOME=/usr/lib/knox
-readonly KNOX_DASK_DIR="${KNOX_HOME}/data/services/dask/0.1.0"
-readonly KNOX_DASKWS_DIR="${KNOX_HOME}/data/services/daskws/0.1.0"
-
 function execute_with_retries() {
-  local -r cmd=$1
-  for ((i = 0; i < 10; i++)); do
+  local -r cmd="$*"
+  for i in {0..9} ; do
     if eval "$cmd"; then
-      return 0
-    fi
+      return 0 ; fi
     sleep 5
   done
   echo "Cmd '${cmd}' failed."
   return 1
 }
 
-DASK_CONDA_ENV="/opt/conda/miniconda3/envs/dask"
-
 function configure_dask_yarn() {
   readonly DASK_YARN_CONFIG_DIR=/etc/dask/
   readonly DASK_YARN_CONFIG_FILE=${DASK_YARN_CONFIG_DIR}/config.yaml
-  dask_python="$(realpath "${DASK_CONDA_ENV}/bin/python")"
   # Minimal custom configuration is required for this
   # setup. Please see https://yarn.dask.org/en/latest/quickstart.html#usage
   # for information on tuning Dask-Yarn environments.
-  mkdir -p ${DASK_YARN_CONFIG_DIR}
+  mkdir -p "${DASK_YARN_CONFIG_DIR}"
 
   cat <<EOF >"${DASK_YARN_CONFIG_FILE}"
 # Config file for Dask Yarn.
@@ -118,16 +100,13 @@ function configure_dask_yarn() {
 # https://yarn.dask.org/en/latest/configuration.html#default-configuration
 
 yarn:
-  environment: python://${dask_python}
+  environment: python://${DASK_CONDA_ENV}/bin/python
 
   worker:
     count: 2
 EOF
 }
 
-enable_worker_service="0"
-ROLE="$(get_metadata_attribute dataproc-role)"
-MASTER="$(get_metadata_attribute dataproc-master)"
 function install_systemd_dask_worker() {
   echo "Installing systemd Dask Worker service..."
   local -r dask_worker_local_dir="/tmp/${DASK_WORKER_SERVICE}"
@@ -164,17 +143,18 @@ EOF
   if [[ "${ROLE}" != "Master" ]]; then
     enable_worker_service="1"
   else
-    local RUN_WORKER_ON_MASTER="$(get_metadata_attribute dask-worker-on-master || echo 'true')"
+    local RUN_WORKER_ON_MASTER="$(get_metadata_attribute dask-worker-on-master 'true')"
     # Enable service on single-node cluster (no workers)
     local worker_count="$(get_metadata_attribute dataproc-worker-count)"
-    if [[ "${worker_count}" == "0" ]]; then RUN_WORKER_ON_MASTER='true'; fi
-
-    if [[ "${RUN_WORKER_ON_MASTER}" == "true" ]]; then
+    if [[ "${worker_count}" == "0" || "${RUN_WORKER_ON_MASTER}" == "true" ]]; then
       enable_worker_service="1"
     fi
   fi
 
-  if [[ "${enable_worker_service}" == "1" ]]; then systemctl enable "${DASK_WORKER_SERVICE}" ; fi
+  if [[ "${enable_worker_service}" == "1" ]]; then
+    systemctl enable "${DASK_WORKER_SERVICE}"
+    systemctl restart "${DASK_WORKER_SERVICE}"
+  fi
 }
 
 function install_systemd_dask_scheduler() {
@@ -184,7 +164,6 @@ function install_systemd_dask_scheduler() {
   local -r dask_scheduler_local_dir="/tmp/${DASK_SCHEDULER_SERVICE}"
 
   mkdir -p "${dask_scheduler_local_dir}"
-
 
   local DASK_SCHEDULER_LAUNCHER="/usr/local/bin/${DASK_SCHEDULER_SERVICE}-launcher.sh"
 
@@ -386,7 +365,6 @@ EOF
   fi
 }
 
-
 function configure_fluentd_for_dask() {
   if [[ "$(hostname -s)" == "${MASTER}" ]]; then
     cat >/etc/google-fluentd/config.d/dataproc-dask.conf <<EOF
@@ -441,15 +419,16 @@ EOF
 
 function install_dask() {
   if is_cuda12 ; then
-    local python_spec="python=3.10"
-    local cuda_spec="cuda-version>=12,<=12.5"
+    local python_spec="python>=3.11"
+    local cuda_spec="cuda-version>=12,<13"
     local dask_spec="dask>=2024.5"
   elif is_cuda11 ; then
-    local python_spec="python=3.9"
+    local python_spec="python>=3.9"
     local cuda_spec="cuda-version>=11,<12.0a0"
     local dask_spec="dask"
   fi
 
+  CONDA_PACKAGES=()
   if [[ "${DASK_RUNTIME}" == 'yarn' ]]; then
     # Pin `distributed` and `dask` package versions to old release
     # because `dask-yarn` 0.9 uses skein in a way which
@@ -478,7 +457,7 @@ function install_dask() {
   mamba="/opt/conda/miniconda3/bin/mamba"
   conda="/opt/conda/miniconda3/bin/conda"
 
-  set +e
+  ( set +e
   for installer in "${mamba}" "${conda}" ; do
     test -d "${DASK_CONDA_ENV}" || \
       time "${installer}" "create" -m -n "dask" -y --no-channel-priority \
@@ -486,7 +465,7 @@ function install_dask() {
       ${CONDA_PACKAGES[*]} \
       "${python_spec}"
     local retval=$?
-    set -e
+    sync
     if [[ "$retval" == "0" ]] ; then
       is_installed="1"
       break
@@ -497,11 +476,15 @@ function install_dask() {
     echo "failed to install dask"
     return 1
   fi
+  )
 }
 
 function main() {
+  # Install Dask
   install_dask
 
+  # In "standalone" mode, Dask relies on a systemd unit to launch.
+  # In "yarn" mode, it relies a config.yaml file.
   if [[ "${DASK_RUNTIME}" == "yarn" ]]; then
     # Create Dask YARN config file
     configure_dask_yarn
@@ -534,7 +517,121 @@ function main() {
   echo "Dask for ${DASK_RUNTIME} successfully initialized."
 }
 
+function exit_handler() (
+  set +e
+  echo "Exit handler invoked"
+
+  # Free conda cache
+  /opt/conda/miniconda3/bin/conda clean -a > /dev/null 2>&1
+
+  # Clear pip cache
+  pip cache purge || echo "unable to purge pip cache"
+
+  # remove the tmpfs conda pkgs_dirs
+  if [[ -d /mnt/shm ]] ; then /opt/conda/miniconda3/bin/conda config --remove pkgs_dirs /mnt/shm ; fi
+
+  # Clean up shared memory mounts
+  for shmdir in /var/cache/apt/archives /var/cache/dnf /mnt/shm ; do
+    if grep -q "^tmpfs ${shmdir}" /proc/mounts ; then
+      rm -rf ${shmdir}/*
+      umount -f ${shmdir}
+    fi
+  done
+
+  # Clean up OS package cache ; re-hold systemd package
+  if is_debuntu ; then
+    apt-get -y -qq clean
+    apt-get -y -qq autoremove
+  else
+    dnf clean all
+  fi
+
+  # print disk usage statistics
+  if is_debuntu ; then
+    # Rocky doesn't have sort -h and fails when the argument is passed
+    du --max-depth 3 -hx / | sort -h | tail -10
+  fi
+
+  # Process disk usage logs from installation period
+  rm -f /tmp/keep-running-df
+  sleep 6s
+  # compute maximum size of disk during installation
+  # Log file contains logs like the following (minus the preceeding #):
+#Filesystem      Size  Used Avail Use% Mounted on
+#/dev/vda2       6.8G  2.5G  4.0G  39% /
+  df --si
+  perl -e '$max=( sort
+                 map { (split)[2] =~ /^(\d+)/ }
+                grep { m:^/: } <STDIN> )[-1];
+print( "maximum-disk-used: $max", $/ );' < /tmp/disk-usage.log
+
+  echo "exit_handler has completed"
+
+  # zero free disk space
+  if [[ -n "$(get_metadata_attribute creating-image)" ]]; then
+    dd if=/dev/zero of=/zero ; sync ; rm -f /zero
+  fi
+
+  return 0
+)
+
+trap exit_handler EXIT
+
+function prepare_to_install() {
+  readonly DEFAULT_CUDA_VERSION="12.4"
+  CUDA_VERSION=$(get_metadata_attribute 'cuda-version' ${DEFAULT_CUDA_VERSION})
+  readonly CUDA_VERSION
+
+  readonly ROLE=$(get_metadata_attribute dataproc-role)
+  readonly MASTER=$(get_metadata_attribute dataproc-master)
+
+  # Dask config
+  DASK_RUNTIME="$(get_metadata_attribute dask-runtime || echo 'standalone')"
+  readonly DASK_RUNTIME
+  readonly DASK_SERVICE=dask-cluster
+  readonly DASK_WORKER_SERVICE=dask-worker
+  readonly DASK_SCHEDULER_SERVICE=dask-scheduler
+  readonly DASK_CONDA_ENV="/opt/conda/miniconda3/envs/dask"
+
+  # Knox config
+  readonly KNOX_HOME=/usr/lib/knox
+  readonly KNOX_DASK_DIR="${KNOX_HOME}/data/services/dask/0.1.0"
+  readonly KNOX_DASKWS_DIR="${KNOX_HOME}/data/services/daskws/0.1.0"
+  enable_worker_service="0"
+
+  free_mem="$(awk '/^MemFree/ {print $2}' /proc/meminfo)"
+  # Write to a ramdisk instead of churning the persistent disk
+  if [[ ${free_mem} -ge 5250000 ]]; then
+    mkdir -p /mnt/shm
+    mount -t tmpfs tmpfs /mnt/shm
+
+    # Download conda packages to tmpfs
+    /opt/conda/miniconda3/bin/conda config --add pkgs_dirs /mnt/shm
+    mount -t tmpfs tmpfs /mnt/shm
+
+    # Download pip packages to tmpfs
+    pip config set global.cache-dir /mnt/shm || echo "unable to set global.cache-dir"
+
+    # Download OS packages to tmpfs
+    if is_debuntu ; then
+      mount -t tmpfs tmpfs /var/cache/apt/archives
+    else
+      mount -t tmpfs tmpfs /var/cache/dnf
+    fi
+  fi
+
+  # Monitor disk usage in a screen session
+  if is_debuntu ; then
+      apt-get install -y -qq screen
+  elif is_rocky ; then
+      dnf -y -q install screen
+  fi
+  rm -f /tmp/disk-usage.log
+  touch /tmp/keep-running-df
+  screen -d -m -US keep-running-df \
+    bash -c 'while [[ -f /tmp/keep-running-df ]] ; do df --si / | tee -a /tmp/disk-usage.log ; sleep 5s ; done'
+}
+
+prepare_to_install
 
 main
-
-df -h

--- a/examples/secure-boot/install_gpu_driver.sh
+++ b/examples/secure-boot/install_gpu_driver.sh
@@ -1249,7 +1249,7 @@ function exit_handler() {
   pip cache purge || echo "unable to purge pip cache"
 
   # remove the tmpfs conda pkgs_dirs
-  if [[ -d /mnt/nvidia-cuda ]] ; then /opt/conda/miniconda3/bin/conda config --remove pkgs_dirs /mnt/nvidia-cuda ; fi
+  if [[ -d /mnt/shm ]] ; then /opt/conda/miniconda3/bin/conda config --remove pkgs_dirs /mnt/shm ; fi
 
   # remove the tmpfs pip cache-dir
   pip config unset global.cache-dir || echo "unable to set global pip cache"
@@ -1309,6 +1309,7 @@ function prepare_to_install(){
   nvsmi_works="0"
   readonly bdcfg="/usr/local/bin/bdconfig"
   download_dir=/tmp/
+  free_mem="$(awk '/^MemFree/ {print $2}' /proc/meminfo)"
   # Write to a ramdisk instead of churning the persistent disk
   if [[ ${free_mem} -ge 5250000 ]]; then
     download_dir="/mnt/shm"

--- a/examples/secure-boot/pre-init.screenrc
+++ b/examples/secure-boot/pre-init.screenrc
@@ -4,14 +4,14 @@
 
 # screen -L -t monitor 0 /bin/bash
 
-screen -L -t 2.2-debian12 1 /bin/bash -x examples/secure-boot/pre-init.sh 2.2-debian12
-screen -L -t 2.1-debian11 2 /bin/bash -x examples/secure-boot/pre-init.sh 2.1-debian11
-screen -L -t 2.0-debian10 3 /bin/bash -x examples/secure-boot/pre-init.sh 2.0-debian10
+screen -L -t 2.0-debian10 1 /bin/bash -x examples/secure-boot/pre-init.sh 2.0-debian10
+screen -L -t 2.0-ubuntu18 2 /bin/bash -x examples/secure-boot/pre-init.sh 2.0-ubuntu18
+screen -L -t 2.0-rocky8   3 /bin/bash -x examples/secure-boot/pre-init.sh 2.0-rocky8
 
-screen -L -t 2.2-ubuntu22 4 /bin/bash -x examples/secure-boot/pre-init.sh 2.2-ubuntu22
-screen -L -t 2.1-ubuntu20 5 /bin/bash -x examples/secure-boot/pre-init.sh 2.1-ubuntu20
-screen -L -t 2.0-ubuntu18 6 /bin/bash -x examples/secure-boot/pre-init.sh 2.0-ubuntu18
+screen -L -t 2.1-debian11 4 /bin/bash -x examples/secure-boot/pre-init.sh 2.1-debian11
+screen -L -t 2.1-rocky8   5 /bin/bash -x examples/secure-boot/pre-init.sh 2.1-rocky8
+screen -L -t 2.1-ubuntu20 6 /bin/bash -x examples/secure-boot/pre-init.sh 2.1-ubuntu20
 
-screen -L -t 2.2-rocky9   7 /bin/bash -x examples/secure-boot/pre-init.sh 2.2-rocky9
-screen -L -t 2.1-rocky8   8 /bin/bash -x examples/secure-boot/pre-init.sh 2.1-rocky8
-screen -L -t 2.0-rocky8   9 /bin/bash -x examples/secure-boot/pre-init.sh 2.0-rocky8
+screen -L -t 2.2-debian12 7 /bin/bash -x examples/secure-boot/pre-init.sh 2.2-debian12
+screen -L -t 2.2-rocky9   8 /bin/bash -x examples/secure-boot/pre-init.sh 2.2-rocky9
+screen -L -t 2.2-ubuntu22 9 /bin/bash -x examples/secure-boot/pre-init.sh 2.2-ubuntu22

--- a/examples/secure-boot/pre-init.screenrc
+++ b/examples/secure-boot/pre-init.screenrc
@@ -5,8 +5,8 @@
 # screen -L -t monitor 0 /bin/bash
 
 screen -L -t 2.0-debian10 1 /bin/bash -x examples/secure-boot/pre-init.sh 2.0-debian10
-screen -L -t 2.0-ubuntu18 2 /bin/bash -x examples/secure-boot/pre-init.sh 2.0-ubuntu18
-screen -L -t 2.0-rocky8   3 /bin/bash -x examples/secure-boot/pre-init.sh 2.0-rocky8
+screen -L -t 2.0-rocky8   2 /bin/bash -x examples/secure-boot/pre-init.sh 2.0-rocky8
+screen -L -t 2.0-ubuntu18 3 /bin/bash -x examples/secure-boot/pre-init.sh 2.0-ubuntu18
 
 screen -L -t 2.1-debian11 4 /bin/bash -x examples/secure-boot/pre-init.sh 2.1-debian11
 screen -L -t 2.1-rocky8   5 /bin/bash -x examples/secure-boot/pre-init.sh 2.1-rocky8

--- a/examples/secure-boot/pre-init.sh
+++ b/examples/secure-boot/pre-init.sh
@@ -107,7 +107,7 @@ case "${dataproc_version}" in
   "2.1-rocky8"   ) disk_size_gb="38" ;; # 41G   35G  6.1G  86% / # cuda-pre-init-2-1-rocky8
   "2.1-ubuntu20" ) disk_size_gb="35" ;; # 37G   32G  4.4G  88% / # cuda-pre-init-2-1-ubuntu20
   "2.2-debian12" ) disk_size_gb="38" ;; # 40G   35G  3.3G  92% / # cuda-pre-init-2-2-debian12
-  "2.2-rocky9"   ) disk_size_gb="39" ;; # 42G   36G  5.9G  86% / # cuda-pre-init-2-2-rocky9
+  "2.2-rocky9"   ) disk_size_gb="40" ;; # 42G   36G  5.9G  86% / # cuda-pre-init-2-2-rocky9
   "2.2-ubuntu22" ) disk_size_gb="38" ;; # 40G   35G  4.8G  88% / # cuda-pre-init-2-2-ubuntu22
 esac
 
@@ -121,17 +121,22 @@ case "${dataproc_version}" in
   "2.0-debian10" ) disk_size_gb="44" ;; # 47G   41G  4.0G  91% / # rapids-pre-init-2-0-debian10
   "2.0-rocky8"   ) disk_size_gb="45" ;; # 49G   42G  7.0G  86% / # rapids-pre-init-2-0-rocky8
   "2.0-ubuntu18" ) disk_size_gb="43" ;; # 45G   40G  4.9G  90% / # rapids-pre-init-2-0-ubuntu18
-  "2.1-debian11" ) disk_size_gb="46" ;; # 53G   43G  7.7G  85% / # rapids-pre-init-2-1-debian11
+  "2.1-debian11" ) disk_size_gb="46" ;; # 49G   43G  3.6G  93% / # rapids-pre-init-2-1-debian11
   "2.1-rocky8"   ) disk_size_gb="48" ;; # 52G   45G  7.2G  87% / # rapids-pre-init-2-1-rocky8
   "2.1-ubuntu20" ) disk_size_gb="45" ;; # 47G   42G  5.2G  89% / # rapids-pre-init-2-1-ubuntu20
   "2.2-debian12" ) disk_size_gb="48" ;; # 51G   45G  3.8G  93% / # rapids-pre-init-2-2-debian12
-  "2.2-rocky9"   ) disk_size_gb="49" ;; # 54G   46G  8.2G  85% / # rapids-pre-init-2-2-rocky9
-  "2.2-ubuntu22" ) disk_size_gb="48" ;; # 52G   45G  7.7G  86% / # rapids-pre-init-2-2-ubuntu22
+  "2.2-rocky9"   ) disk_size_gb="49" ;; # 53G   46G  7.2G  87% / # rapids-pre-init-2-2-rocky9
+  "2.2-ubuntu22" ) disk_size_gb="48" ;; # 50G   45G  5.6G  89% / # rapids-pre-init-2-2-ubuntu22
 esac
 
 #disk_size_gb="50"
 
-# Install rapids on dask base image
+# Install dask with rapids on base image
 PURPOSE="rapids-pre-init"
 customization_script="examples/secure-boot/rapids.sh"
+time generate_from_base_purpose "cuda-pre-init"
+
+# Install dask without rapids on base image
+PURPOSE="dask-pre-init"
+customization_script="examples/secure-boot/dask.sh"
 time generate_from_base_purpose "cuda-pre-init"

--- a/examples/secure-boot/pre-init.sh
+++ b/examples/secure-boot/pre-init.sh
@@ -18,6 +18,8 @@
 
 set -e
 readonly timestamp="$(date +%F-%H-%M)"
+#readonly timestamp="2024-10-19-18-46"
+#readonly timestamp="2024-10-21-19-29"
 
 IMAGE_VERSION="$1"
 if [[ -z "${IMAGE_VERSION}" ]] ; then
@@ -42,8 +44,8 @@ metadata="public_secret_name=${public_secret_name}"
 metadata="${metadata},private_secret_name=${private_secret_name}"
 metadata="${metadata},secret_project=${secret_project}"
 metadata="${metadata},secret_version=${secret_version}"
-metadata="${metadata},dask-runtime=yarn"
-metadata="${metadata},rapids-runtime=SPARK"
+metadata="${metadata},dask-runtime=standalone"
+metadata="${metadata},rapids-runtime=DASK"
 metadata="${metadata},cuda-version=12.4"
 
 # If no OS family specified, default to debian
@@ -57,53 +59,30 @@ else
   dataproc_version="${IMAGE_VERSION}"
 fi
 
-# base image -> cuda
-# case "${dataproc_version}" in
-#   "2.2-rocky9"   ) disk_size_gb="54" ;;
-#   "2.1-rocky8"   ) disk_size_gb="36" ;;
-#   "2.0-rocky8"   ) disk_size_gb="33" ;;
-#   "2.2-ubuntu22" ) disk_size_gb="40" ;;
-#   "2.1-ubuntu20" ) disk_size_gb="37" ;;
-#   "2.0-ubuntu18" ) disk_size_gb="37" ;;
-#   "2.2-debian12" ) disk_size_gb="40" ;;
-#   "2.1-debian11" ) disk_size_gb="40" ;;
-#   "2.0-debian10" ) disk_size_gb="40" ;;
-# esac
-
-# cuda image -> dask
-# case "${dataproc_version}" in
-#   "2.2-rocky9"   ) disk_size_gb="54" ;;
-#   "2.1-rocky8"   ) disk_size_gb="37" ;;
-#   "2.0-rocky8"   ) disk_size_gb="40" ;;
-#   "2.2-ubuntu22" ) disk_size_gb="45" ;;
-#   "2.1-ubuntu20" ) disk_size_gb="42" ;;
-#   "2.0-ubuntu18" ) disk_size_gb="37" ;;
-#   "2.2-debian12" ) disk_size_gb="46" ;;
-#   "2.1-debian11" ) disk_size_gb="40" ;;
-#   "2.0-debian10" ) disk_size_gb="40" ;;
-# esac
-
-# dask image -> rapids
-case "${dataproc_version}" in
-  "2.2-rocky9"   ) disk_size_gb="54" ;;
-  "2.1-rocky8"   ) disk_size_gb="37" ;;
-  "2.0-rocky8"   ) disk_size_gb="40" ;;
-  "2.2-ubuntu22" ) disk_size_gb="45" ;;
-  "2.1-ubuntu20" ) disk_size_gb="42" ;;
-  "2.0-ubuntu18" ) disk_size_gb="37" ;;
-  "2.2-debian12" ) disk_size_gb="46" ;;
-  "2.1-debian11" ) disk_size_gb="40" ;;
-  "2.0-debian10" ) disk_size_gb="40" ;;
-esac
-
-
 function generate() {
   local extra_args="$*"
-  set -x
+  local image_name="${PURPOSE}-${dataproc_version/\./-}-${timestamp}"
+  local img_list="$(gcloud compute images list --filter="name=( \"${image_name}\" )" 2>&1)"
+  set +e
+  echo ${img_list} | grep -q 'Listed 0 items.'
+  if [[ $? != 0 ]] ; then
+#  if gcloud compute images describe "${image_name}" > /dev/null ; then
+    echo "Image already exists"
+    return
+  fi
+  local instance_list="$(gcloud compute instances list --zones "${custom_image_zone}" --filter="name=( \"${image_name}-install\" )" 2>&1)"
+  echo ${instance_list} | grep -q 'Listed 0 items.'
+  if [[ $? != 0 ]]; then
+#  if gcloud compute instances describe "${image_name}-install" > /dev/null ; then
+    # if previous run ended without cleanup...
+    gcloud -q compute instances delete "${image_name}-install" \
+      --zone "${custom_image_zone}"
+  fi
+  set -xe
   python generate_custom_image.py \
     --machine-type         "n1-standard-4" \
     --accelerator          "type=nvidia-tesla-t4" \
-    --image-name           "${PURPOSE}-${dataproc_version/\./-}-${timestamp}" \
+    --image-name           "${image_name}" \
     --customization-script "${customization_script}" \
     --service-account      "${GSA}" \
     --metadata             "${metadata}" \
@@ -122,26 +101,61 @@ function generate_from_dataproc_version() {
 }
 
 function generate_from_base_purpose() {
-  local base_purpose="$1"
-  generate --base-image-uri "https://www.googleapis.com/compute/v1/projects/${PROJECT_ID}/global/images/${base_purpose}-${dataproc_version/\./-}-${timestamp}"
+  generate --base-image-uri "https://www.googleapis.com/compute/v1/projects/${PROJECT_ID}/global/images/${1}-${dataproc_version/\./-}-${timestamp}"
 }
+
+# base image -> cuda
+case "${dataproc_version}" in
+  "2.0-debian10" ) disk_size_gb="31" ;; # 40G   29G  9.1G  76% / # cuda-pre-init-2-0-debian10
+  "2.0-rocky8"   ) disk_size_gb="32" ;; # 33G   30G  3.4G  90% / # cuda-pre-init-2-0-rocky8
+  "2.0-ubuntu18" ) disk_size_gb="31" ;; # 36G   29G  7.0G  81% / # cuda-pre-init-2-0-ubuntu18
+  "2.1-debian11" ) disk_size_gb="37" ;; # 40G   35G  2.7G  93% / # cuda-pre-init-2-1-debian11
+  "2.1-rocky8"   ) disk_size_gb="35" ;; # 36G   33G  3.3G  91% / # cuda-pre-init-2-1-rocky8
+  "2.1-ubuntu20" ) disk_size_gb="36" ;; # 36G   34G  2.1G  95% / # cuda-pre-init-2-1-ubuntu20
+  "2.2-debian12" ) disk_size_gb="39" ;; # 40G   37G  1.1G  98% / # cuda-pre-init-2-2-debian12
+  "2.2-rocky9"   ) disk_size_gb="36" ;; # 54G   34G   20G  63% / # cuda-pre-init-2-2-rocky9
+  "2.2-ubuntu22" ) disk_size_gb="39" ;; # 39G   37G  2.4G  94% / # cuda-pre-init-2-2-ubuntu22
+esac
 
 # Install GPU drivers + cuda on dataproc base image
 PURPOSE="cuda-pre-init"
 customization_script="examples/secure-boot/install_gpu_driver.sh"
-
 time generate_from_dataproc_version "${dataproc_version}"
 
+# cuda image -> dask
+case "${dataproc_version}" in
+  "2.0-debian10" ) disk_size_gb="34" ;; # 40G   32G  6.4G  83% / # dask-pre-init-2-0-debian10
+  "2.0-rocky8"   ) disk_size_gb="35" ;; # 65G   33G   33G  51% / # dask-pre-init-2-0-rocky8
+  "2.0-ubuntu18" ) disk_size_gb="35" ;; # 36G   32G  4.3G  89% / # dask-pre-init-2-0-ubuntu18
+  "2.1-debian11" ) disk_size_gb="40" ;; # 40G   38G  111M 100% / # dask-pre-init-2-1-debian11
+  "2.1-rocky8"   ) disk_size_gb="37" ;; # 37G   36G  1.7G  96% / # dask-pre-init-2-1-rocky8
+  "2.1-ubuntu20" ) disk_size_gb="38" ;; # 41G   37G  4.3G  90% / # dask-pre-init-2-1-ubuntu20
+  "2.2-debian12" ) disk_size_gb="41" ;; # 46G   39G  4.4G  90% / # dask-pre-init-2-2-debian12
+  "2.2-rocky9"   ) disk_size_gb="39" ;; # 54G   37G   18G  68% / # dask-pre-init-2-2-rocky9
+  "2.2-ubuntu22" ) disk_size_gb="41" ;; # 44G   39G  4.9G  89% / # dask-pre-init-2-2-ubuntu22
+esac
+
 # Install dask on cuda base image
-base_purpose="${PURPOSE}"
 PURPOSE="dask-pre-init"
 customization_script="examples/secure-boot/dask.sh"
+time generate_from_base_purpose "cuda-pre-init"
 
-time generate_from_base_purpose "${base_purpose}"
+# dask image -> rapids
+case "${dataproc_version}" in
+   "2.0-debian10" ) disk_size_gb="52" ;; # 64G   49G   13G  80% / # rapids-pre-init-2-0-debian10
+   "2.0-rocky8"   ) disk_size_gb="52" ;; # 65G   50G   15G  78% / # rapids-pre-init-2-0-rocky8
+   "2.0-ubuntu18" ) disk_size_gb="53" ;; # 63G   49G   14G  78% / # rapids-pre-init-2-0-ubuntu18
+   "2.1-debian11" ) disk_size_gb="58" ;; # 64G   55G  6.2G  90% / # rapids-pre-init-2-1-debian11
+   "2.1-rocky8"   ) disk_size_gb="55" ;; # 65G   53G   12G  82% / # rapids-pre-init-2-1-rocky8
+   "2.1-ubuntu20" ) disk_size_gb="58" ;; # 63G   54G  9.1G  86% / # rapids-pre-init-2-1-ubuntu20
+   "2.2-debian12" ) disk_size_gb="59" ;; # 64G   56G  5.2G  92% / # rapids-pre-init-2-2-debian12
+   "2.2-rocky9"   ) disk_size_gb="56" ;; # 65G   54G   12G  83% / # rapids-pre-init-2-2-rocky9
+   "2.2-ubuntu22" ) disk_size_gb="60" ;; # 63G   56G  7.1G  89% / # rapids-pre-init-2-2-ubuntu22
+esac
+
+#disk_size_gb="65"
 
 # Install rapids on dask base image
-base_purpose="${PURPOSE}"
 PURPOSE="rapids-pre-init"
 customization_script="examples/secure-boot/rapids.sh"
-
-time generate_from_base_purpose "${base_purpose}"
+time generate_from_base_purpose "dask-pre-init"

--- a/examples/secure-boot/rapids.sh
+++ b/examples/secure-boot/rapids.sh
@@ -431,6 +431,7 @@ function install_dask_rapids() {
     local numba_spec="numba"
   fi
 
+  rapids_spec="rapids=${RAPIDS_VERSION}"
   CONDA_PACKAGES=()
   if [[ "${DASK_RUNTIME}" == 'yarn' ]]; then
     # Pin `distributed` and `dask` package versions to old release
@@ -440,6 +441,7 @@ function install_dask_rapids() {
 
     dask_spec="dask<2022.2"
     python_spec="python>=3.7,<3.8.0a0"
+    rapids_spec="rapids<=24.05"
     if is_ubuntu18 ; then
       # the libuuid.so.1 distributed with fiona 1.8.22 dumps core when calling uuid_generate_time_generic
       CONDA_PACKAGES+=("fiona<1.8.22")
@@ -449,7 +451,7 @@ function install_dask_rapids() {
 
   CONDA_PACKAGES+=(
     "${cuda_spec}"
-    "rapids=${RAPIDS_VERSION}"
+    "${rapids_spec}"
     "${dask_spec}"
     "dask-bigquery"
     "dask-ml"
@@ -471,7 +473,8 @@ function install_dask_rapids() {
       time "${installer}" "create" -m -n 'dask-rapids' -y --no-channel-priority \
       -c 'conda-forge' -c 'nvidia' -c 'rapidsai'  \
       ${CONDA_PACKAGES[*]} \
-      "${python_spec}"
+      "${python_spec}" \
+      > "${install_log}" 2>&1 || { cat "${install_log}" && exit -4 ; }
     local retval=$?
     sync
     if [[ "$retval" == "0" ]] ; then
@@ -496,7 +499,7 @@ function main() {
   if [[ "${DASK_RUNTIME}" == "yarn" ]]; then
     # Create Dask YARN config file
     configure_dask_yarn
-  elif [[ "${DASK_RUNTIME}" == "standalone" ]]; then
+  else
     # Create Dask service
     install_systemd_dask_service
 
@@ -517,9 +520,6 @@ function main() {
     if [[ "${DASK_CLOUD_LOGGING}" == "true" ]]; then
       configure_fluentd_for_dask
     fi
-  else
-    echo "Unsupported Dask Runtime: ${DASK_RUNTIME}"
-    exit 1
   fi
 
   echo "Dask RAPIDS for ${DASK_RUNTIME} successfully initialized."
@@ -570,17 +570,17 @@ function exit_handler() (
   fi
 
   # Process disk usage logs from installation period
-  rm -f /tmp/keep-running-df
+  rm -f "${tmpdir}/keep-running-df"
   sleep 6s
   # compute maximum size of disk during installation
   # Log file contains logs like the following (minus the preceeding #):
 #Filesystem      Size  Used Avail Use% Mounted on
 #/dev/vda2       6.8G  2.5G  4.0G  39% /
-  df --si
+  df -h | tee -a "${tmpdir}/disk-usage.log"
   perl -e '$max=( sort
                    map { (split)[2] =~ /^(\d+)/ }
                   grep { m:^/: } <STDIN> )[-1];
-print( "maximum-disk-used: $max", $/ );' < /tmp/disk-usage.log
+print( "maximum-disk-used: $max", $/ );' < "${tmpdir}/disk-usage.log"
 
   echo "exit_handler has completed"
 
@@ -591,8 +591,6 @@ print( "maximum-disk-used: $max", $/ );' < /tmp/disk-usage.log
 
   return 0
 )
-
-trap exit_handler EXIT
 
 function prepare_to_install(){
   readonly DEFAULT_CUDA_VERSION="12.4"
@@ -626,6 +624,7 @@ function prepare_to_install(){
   free_mem="$(awk '/^MemFree/ {print $2}' /proc/meminfo)"
   # Write to a ramdisk instead of churning the persistent disk
   if [[ ${free_mem} -ge 5250000 ]]; then
+    tmpdir=/mnt/shm
     mkdir -p /mnt/shm
     mount -t tmpfs tmpfs /mnt/shm
 
@@ -642,18 +641,22 @@ function prepare_to_install(){
     else
       mount -t tmpfs tmpfs /var/cache/dnf
     fi
+  else
+    tmpdir=/tmp
   fi
+  install_log="${tmpdir}/install.log"
+  trap exit_handler EXIT
 
   # Monitor disk usage in a screen session
   if is_debuntu ; then
       apt-get install -y -qq screen
-  elif is_rocky ; then
+  else
       dnf -y -q install screen
   fi
-  rm -f /tmp/disk-usage.log
-  touch /tmp/keep-running-df
+  df -h | tee "${tmpdir}/disk-usage.log"
+  touch "${tmpdir}/keep-running-df"
   screen -d -m -US keep-running-df \
-    bash -c 'while [[ -f /tmp/keep-running-df ]] ; do df --si / | tee -a /tmp/disk-usage.log ; sleep 5s ; done'
+    bash -c "while [[ -f ${tmpdir}/keep-running-df ]] ; do df -h / | tee -a ${tmpdir}/disk-usage.log ; sleep 5s ; done"
 }
 
 prepare_to_install

--- a/examples/secure-boot/rapids.sh
+++ b/examples/secure-boot/rapids.sh
@@ -21,49 +21,56 @@ set -euxo pipefail
 
 function os_id()       { grep '^ID=' /etc/os-release | cut -d= -f2 | xargs ; }
 function is_ubuntu()   { [[ "$(os_id)" == 'ubuntu' ]] ; }
+function is_ubuntu18() { is_ubuntu && [[ "$(os_version)" == '18.04'* ]] ; }
 function is_debian()   { [[ "$(os_id)" == 'debian' ]] ; }
 function is_debuntu()  { is_debian || is_ubuntu ; }
 
-# Detect dataproc image version from its various names
-if (! test -v DATAPROC_IMAGE_VERSION) && test -v DATAPROC_VERSION; then
-  DATAPROC_IMAGE_VERSION="${DATAPROC_VERSION}"
-fi
-
-function get_metadata_attribute() {
-  local -r attribute_name=$1
-  local -r default_value="${2:-}"
-  /usr/share/google/get_metadata_value "attributes/${attribute_name}" || echo -n "${default_value}"
+function print_metadata_value() {
+  local readonly tmpfile=$(mktemp)
+  http_code=$(curl -f "${1}" -H "Metadata-Flavor: Google" -w "%{http_code}" \
+    -s -o ${tmpfile} 2>/dev/null)
+  local readonly return_code=$?
+  # If the command completed successfully, print the metadata value to stdout.
+  if [[ ${return_code} == 0 && ${http_code} == 200 ]]; then
+    cat ${tmpfile}
+  fi
+  rm -f ${tmpfile}
+  return ${return_code}
 }
 
-DEFAULT_CUDA_VERSION="12.4"
+function print_metadata_value_if_exists() {
+  local return_code=1
+  local readonly url=$1
+  print_metadata_value ${url}
+  return_code=$?
+  return ${return_code}
+}
 
-# RAPIDS config
-readonly RAPIDS_RUNTIME=$(get_metadata_attribute 'rapids-runtime' 'DASK')
-readonly DEFAULT_CUDA_VERSION
-CUDA_VERSION=$(get_metadata_attribute 'cuda-version' ${DEFAULT_CUDA_VERSION})
+function get_metadata_value() {
+  set +x
+  local readonly varname=$1
+  local -r MDS_PREFIX=http://metadata.google.internal/computeMetadata/v1
+  # Print the instance metadata value.
+  print_metadata_value_if_exists ${MDS_PREFIX}/instance/${varname}
+  return_code=$?
+  # If the instance doesn't have the value, try the project.
+  if [[ ${return_code} != 0 ]]; then
+    print_metadata_value_if_exists ${MDS_PREFIX}/project/${varname}
+    return_code=$?
+  fi
+  set -x
+  return ${return_code}
+}
 
-readonly CUDA_VERSION
+function get_metadata_attribute() (
+  set +x
+  local -r attribute_name="$1"
+  local -r default_value="${2:-}"
+  get_metadata_value "attributes/${attribute_name}" || echo -n "${default_value}"
+)
+
 function is_cuda12() { [[ "${CUDA_VERSION%%.*}" == "12" ]] ; }
 function is_cuda11() { [[ "${CUDA_VERSION%%.*}" == "11" ]] ; }
-
-readonly DEFAULT_DASK_RAPIDS_VERSION="24.08"
-readonly RAPIDS_VERSION=$(get_metadata_attribute 'rapids-version' ${DEFAULT_DASK_RAPIDS_VERSION})
-
-readonly ROLE=$(/usr/share/google/get_metadata_value attributes/dataproc-role)
-readonly MASTER=$(/usr/share/google/get_metadata_value attributes/dataproc-master)
-
-readonly RUN_WORKER_ON_MASTER=$(get_metadata_attribute 'dask-cuda-worker-on-master' 'true')
-
-# Scala config
-readonly SCALA_VER="2.12"
-
-# Dask config
-readonly DASK_RUNTIME="$(/usr/share/google/get_metadata_value attributes/dask-runtime || echo 'standalone')"
-readonly DASK_LAUNCHER=/usr/local/bin/dask-launcher.sh
-readonly DASK_SERVICE=dask-cluster
-readonly DASK_WORKER_SERVICE=dask-worker
-readonly DASK_SCHEDULER_SERVICE=dask-scheduler
-readonly DASK_YARN_CONFIG_FILE=/etc/dask/config.yaml
 
 function execute_with_retries() {
   local -r cmd="$*"
@@ -76,62 +83,30 @@ function execute_with_retries() {
   return 1
 }
 
-readonly conda_env="/opt/conda/miniconda3/envs/dask-rapids"
-function install_dask_rapids() {
-  if is_cuda12 ; then
-    local python_spec="python>=3.11"
-    local cuda_spec="cuda-version>=12,<13"
-    local dask_spec="dask>=2024.5"
-    local numba_spec="numba"
-  elif is_cuda11 ; then
-    local python_spec="python>=3.9"
-    local cuda_spec="cuda-version>=11,<=11.8"
-    local dask_spec="dask"
-    local numba_spec="numba"
-  fi
+function configure_dask_yarn() {
+  readonly DASK_YARN_CONFIG_DIR=/etc/dask/
+  readonly DASK_YARN_CONFIG_FILE=${DASK_YARN_CONFIG_DIR}/config.yaml
+  # Minimal custom configuration is required for this
+  # setup. Please see https://yarn.dask.org/en/latest/quickstart.html#usage
+  # for information on tuning Dask-Yarn environments.
+  mkdir -p "${DASK_YARN_CONFIG_DIR}"
 
-  local CONDA_PACKAGES=(
-    "${cuda_spec}"
-    "rapids=${RAPIDS_VERSION}"
-    "${dask_spec}"
-    "dask-bigquery"
-    "dask-ml"
-    "dask-sql"
-    "cudf"
-    "${numba_spec}"
-  )
+  cat <<EOF >"${DASK_YARN_CONFIG_FILE}"
+# Config file for Dask Yarn.
+#
+# These values are joined on top of the default config, found at
+# https://yarn.dask.org/en/latest/configuration.html#default-configuration
 
-  # Install cuda, rapids, dask
-  local is_installed="0"
-  mamba="/opt/conda/miniconda3/bin/mamba"
-  conda="/opt/conda/miniconda3/bin/conda"
+yarn:
+  environment: python://${DASK_CONDA_ENV}/bin/python
 
-  "${conda}" remove -n dask --all || echo "unable to remove conda environment [dask]"
-
-  for installer in "${mamba}" "${conda}" ; do
-    set +e
-    test -d "${conda_env}" || \
-      time "${installer}" "create" -m -n 'dask-rapids' -y --no-channel-priority \
-      -c 'conda-forge' -c 'nvidia' -c 'rapidsai'  \
-      ${CONDA_PACKAGES[*]} \
-      "${python_spec}"
-    sync
-    if [[ "$?" == "0" ]] ; then
-      is_installed="1"
-      break
-    else
-      "${conda}" config --set channel_priority flexible
-    fi
-    set -e
-  done
-  if [[ "${is_installed}" == "0" ]]; then
-    echo "failed to install dask"
-    return 1
-  fi
-  set -e
+  worker:
+    count: 2
+    gpus: 1
+    class: "dask_cuda.CUDAWorker"
+EOF
 }
 
-enable_worker_service="0"
 function install_systemd_dask_worker() {
   echo "Installing systemd Dask Worker service..."
   local -r dask_worker_local_dir="/tmp/${DASK_WORKER_SERVICE}"
@@ -145,7 +120,7 @@ function install_systemd_dask_worker() {
 LOGFILE="/var/log/${DASK_WORKER_SERVICE}.log"
 nvidia-smi -c DEFAULT
 echo "dask-cuda-worker starting, logging to \${LOGFILE}"
-${conda_env}/bin/dask-cuda-worker "${MASTER}:8786" --local-directory="${dask_worker_local_dir}" --memory-limit=auto >> "\${LOGFILE}" 2>&1
+${DASK_CONDA_ENV}/bin/dask-cuda-worker "${MASTER}:8786" --local-directory="${dask_worker_local_dir}" --memory-limit=auto >> "\${LOGFILE}" 2>&1
 EOF
 
   chmod 750 "${DASK_WORKER_LAUNCHER}"
@@ -169,8 +144,9 @@ EOF
   if [[ "${ROLE}" != "Master" ]]; then
     enable_worker_service="1"
   else
+     local RUN_WORKER_ON_MASTER=$(get_metadata_attribute dask-cuda-worker-on-master 'true')
     # Enable service on single-node cluster (no workers)
-    local worker_count="$(/usr/share/google/get_metadata_value attributes/dataproc-worker-count)"
+    local worker_count="$(get_metadata_attribute dataproc-worker-count)"
     if [[ "${worker_count}" == "0" || "${RUN_WORKER_ON_MASTER}" == "true" ]]; then
       enable_worker_service="1"
     fi
@@ -182,43 +158,371 @@ EOF
   fi
 }
 
-function configure_dask_yarn() {
-  # Replace config file on cluster.
-  mkdir -p "$(dirname "${DASK_YARN_CONFIG_FILE}")"
-  cat <<EOF >"${DASK_YARN_CONFIG_FILE}"
-# Config file for Dask Yarn.
-#
-# These values are joined on top of the default config, found at
-# https://yarn.dask.org/en/latest/configuration.html#default-configuration
+function install_systemd_dask_scheduler() {
+  # only run scheduler on primary master
+  if [[ "$(hostname -s)" != "${MASTER}" ]]; then return ; fi
+  echo "Installing systemd Dask Scheduler service..."
+  local -r dask_scheduler_local_dir="/tmp/${DASK_SCHEDULER_SERVICE}"
 
-yarn:
-  environment: python://${conda_env}/bin/python
+  mkdir -p "${dask_scheduler_local_dir}"
 
-  worker:
-    count: 2
-    gpus: 1
-    class: "dask_cuda.CUDAWorker"
+  local DASK_SCHEDULER_LAUNCHER="/usr/local/bin/${DASK_SCHEDULER_SERVICE}-launcher.sh"
+
+  cat <<EOF >"${DASK_SCHEDULER_LAUNCHER}"
+#!/bin/bash
+LOGFILE="/var/log/${DASK_SCHEDULER_SERVICE}.log"
+echo "dask scheduler starting, logging to \${LOGFILE}"
+${DASK_CONDA_ENV}/bin/dask scheduler >> "\${LOGFILE}" 2>&1
 EOF
+
+  chmod 750 "${DASK_SCHEDULER_LAUNCHER}"
+
+  local -r dask_service_file="/usr/lib/systemd/system/${DASK_SCHEDULER_SERVICE}.service"
+  cat <<EOF >"${dask_service_file}"
+[Unit]
+Description=Dask Scheduler Service
+[Service]
+Type=simple
+Restart=on-failure
+ExecStart=/bin/bash -c 'exec ${DASK_SCHEDULER_LAUNCHER}'
+[Install]
+WantedBy=multi-user.target
+EOF
+  chmod a+r "${dask_service_file}"
+
+  systemctl daemon-reload
+
+  # Enable the service
+  systemctl enable "${DASK_SCHEDULER_SERVICE}"
+}
+
+function install_systemd_dask_service() {
+  install_systemd_dask_scheduler
+  install_systemd_dask_worker
+}
+
+function restart_knox() {
+  systemctl stop knox
+  rm -rf "${KNOX_HOME}/data/deployments/*"
+  systemctl start knox
+}
+
+function configure_knox_for_dask() {
+  if [[ ! -d "${KNOX_HOME}" ]]; then
+    echo "Skip configuring Knox rules for Dask"
+    return 0
+  fi
+
+  local DASK_UI_PORT=8787
+  if [[ -f /etc/knox/conf/topologies/default.xml ]]; then
+    sed -i \
+      "/<\/topology>/i <service><role>DASK<\/role><url>http://localhost:${DASK_UI_PORT}<\/url><\/service> <service><role>DASKWS<\/role><url>ws:\/\/${MASTER}:${DASK_UI_PORT}<\/url><\/service>" \
+      /etc/knox/conf/topologies/default.xml
+  fi
+
+  mkdir -p "${KNOX_DASK_DIR}"
+
+  cat >"${KNOX_DASK_DIR}/service.xml" <<'EOF'
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+
+<service role="DASK" name="dask" version="0.1.0">
+  <policies>
+    <policy role="webappsec"/>
+    <policy role="authentication" name="Anonymous"/>
+    <policy role="rewrite"/>
+    <policy role="authorization"/>
+  </policies>
+
+  <routes>
+    <!-- Javascript paths -->
+    <route path="/dask/**/*.js">
+      <rewrite apply="DASK/dask/inbound/js/dask" to="request.url"/>
+      <rewrite apply="DASK/dask/outbound/js" to="response.body"/>
+    </route>
+    <route path="/dask/**/*.js?**">
+      <rewrite apply="DASK/dask/inbound/js/dask" to="request.url"/>
+      <rewrite apply="DASK/dask/outbound/js" to="response.body"/>
+    </route>
+
+    <!-- CSS paths -->
+    <route path="/dask/**/*.css">
+      <rewrite apply="DASK/dask/inbound/css/dask" to="request.url"/>
+    </route>
+
+    <!-- General path routing -->
+    <route path="/dask">
+      <rewrite apply="DASK/dask/inbound/root" to="request.url"/>
+      <rewrite apply="DASK/dask/outbound/headers" to="response.headers"/>
+    </route>
+    <route path="/dask/**">
+      <rewrite apply="DASK/dask/inbound/root/path" to="request.url"/>
+      <rewrite apply="DASK/dask/outbound/headers" to="response.headers"/>
+      <rewrite apply="DASK/dask/outbound/logs" to="response.body"/>
+    </route>
+    <route path="/dask/**?**">
+      <rewrite apply="DASK/dask/inbound/root/query" to="request.url"/>
+      <rewrite apply="DASK/dask/outbound/headers" to="response.headers"/>
+      <rewrite apply="DASK/dask/outbound/logs" to="response.body"/>
+    </route>
+  </routes>
+  <dispatch classname="org.apache.knox.gateway.dispatch.PassAllHeadersNoChunkedPostDispatch"/>
+</service>
+EOF
+
+  cat >"${KNOX_DASK_DIR}/rewrite.xml" <<'EOF'
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+
+<rules>
+  <rule dir="IN" name="DASK/dask/inbound/js/dask" pattern="http://*:*/**/dask/{**}?{**}">
+    <rewrite template="{$serviceUrl[DASK]}/{**}?{**}"/>
+  </rule>
+  <rule dir="IN" name="DASK/dask/inbound/root" pattern="http://*:*/**/dask">
+    <rewrite template="{$serviceUrl[DASK]}"/>
+  </rule>
+  <rule dir="IN" name="DASK/dask/inbound/root/path" pattern="http://*:*/**/dask/{**}">
+    <rewrite template="{$serviceUrl[DASK]}/{**}"/>
+  </rule>
+  <rule dir="IN" name="DASK/dask/inbound/root/query" pattern="http://*:*/**/dask/{**}?{**}">
+    <rewrite template="{$serviceUrl[DASK]}/{**}?{**}"/>
+  </rule>
+  <rule dir="IN" name="DASK/dask/inbound/css/dask" pattern="http://*:*/**/dask/{**}?{**}">
+    <rewrite template="{$serviceUrl[DASK]}/{**}?{**}"/>
+  </rule>
+  <!-- without the /gateway/default prefix -->
+  <rule dir="IN" name="DASK/dask/inbound/root/noprefix" pattern="http://*:*/dask">
+    <rewrite template="{$serviceUrl[DASK]}"/>
+  </rule>
+
+  <rule dir="OUT" name="DASK/dask/outbound/logs" pattern="/logs">
+    <rewrite template="{$frontend[path]}/dask/info/logs"/>
+  </rule>
+
+  <!-- Rewrite redirect responses Location header -->
+  <filter name="DASK/dask/outbound/headers">
+    <content type="application/x-http-headers">
+      <apply path="Location" rule="DASK/dask/outbound/headers/location"/>
+    </content>
+  </filter>
+
+  <rule dir="OUT" name="DASK/dask/outbound/headers/location" flow="OR">
+    <match pattern="*://*:*/">
+      <rewrite template="{$frontend[path]}/dask/"/>
+    </match>
+    <match pattern="*://*:*/{**}">
+      <rewrite template="{$frontend[path]}/dask/{**}"/>
+    </match>
+    <match pattern="*://*:*/{**}?{**}">
+      <rewrite template="{$frontend[path]}/dask/{**}?{**}"/>
+    </match>
+    <match pattern="/{**}">
+      <rewrite template="{$frontend[path]}/dask/{**}"/>
+    </match>
+    <match pattern="/{**}?{**}">
+      <rewrite template="{$frontend[path]}/dask/{**}?{**}"/>
+    </match>
+  </rule>
+</rules>
+EOF
+
+  mkdir -p "${KNOX_DASKWS_DIR}"
+
+  cat >"${KNOX_DASKWS_DIR}/service.xml" <<'EOF'
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+
+<service role="DASKWS" name="daskws" version="0.1.0">
+  <policies>
+    <policy role="webappsec"/>
+    <policy role="authentication" name="Anonymous"/>
+    <policy role="rewrite"/>
+    <policy role="authorization"/>
+  </policies>
+
+  <routes>
+
+    <route path="/dask/**/ws">
+      <rewrite apply="DASKWS/daskws/inbound/ws" to="request.url"/>
+    </route>
+
+  </routes>
+  <dispatch classname="org.apache.knox.gateway.dispatch.PassAllHeadersNoChunkedPostDispatch"/>
+</service>
+EOF
+
+  cat >"${KNOX_DASKWS_DIR}/rewrite.xml" <<'EOF'
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+
+<rules>
+  <rule dir="IN" name="DASKWS/daskws/inbound/ws" pattern="ws://*:*/**/dask/{**}/ws">
+    <rewrite template="{$serviceUrl[DASKWS]}/{**}/ws"/>
+  </rule>
+</rules>
+EOF
+
+  chown -R knox:knox "${KNOX_DASK_DIR}" "${KNOX_DASKWS_DIR}"
+
+  # Do not restart knox during pre-init script run
+  if [[ -n "${ROLE}" ]]; then
+    restart_knox
+  fi
+}
+
+function configure_fluentd_for_dask() {
+  if [[ "$(hostname -s)" == "${MASTER}" ]]; then
+    cat >/etc/google-fluentd/config.d/dataproc-dask.conf <<EOF
+# Fluentd config for Dask logs
+
+# Dask scheduler
+<source>
+  @type tail
+  path /var/log/dask-scheduler.log
+  pos_file /var/tmp/fluentd.dataproc.dask.scheduler.pos
+  read_from_head true
+  tag google.dataproc.dask-scheduler
+  <parse>
+    @type none
+  </parse>
+</source>
+
+<filter google.dataproc.dask-scheduler>
+  @type record_transformer
+  <record>
+    filename dask-scheduler.log
+  </record>
+</filter>
+EOF
+  fi
+
+  if [[ "${enable_worker_service}" == "1" ]]; then
+    cat >>/etc/google-fluentd/config.d/dataproc-dask.conf <<EOF
+# Dask worker
+<source>
+  @type tail
+  path /var/log/dask-worker.log
+  pos_file /var/tmp/fluentd.dataproc.dask.worker.pos
+  read_from_head true
+  tag google.dataproc.dask-worker
+  <parse>
+    @type none
+  </parse>
+</source>
+
+<filter google.dataproc.dask-worker>
+  @type record_transformer
+  <record>
+    filename dask-worker.log
+  </record>
+</filter>
+EOF
+  fi
+
+  systemctl restart google-fluentd
+}
+
+function install_dask_rapids() {
+  if is_cuda12 ; then
+    local python_spec="python>=3.11"
+    local cuda_spec="cuda-version>=12,<13"
+    local dask_spec="dask>=2024.5"
+    local numba_spec="numba"
+  elif is_cuda11 ; then
+    local python_spec="python>=3.9"
+    local cuda_spec="cuda-version>=11,<12.0a0"
+    local dask_spec="dask"
+    local numba_spec="numba"
+  fi
+
+  CONDA_PACKAGES=()
+  if [[ "${DASK_RUNTIME}" == 'yarn' ]]; then
+    # Pin `distributed` and `dask` package versions to old release
+    # because `dask-yarn` 0.9 uses skein in a way which
+    # is not compatible with `distributed` package 2022.2 and newer:
+    # https://github.com/dask/dask-yarn/issues/155
+
+    dask_spec="dask<2022.2"
+    python_spec="python>=3.7,<3.8.0a0"
+    if is_ubuntu18 ; then
+      # the libuuid.so.1 distributed with fiona 1.8.22 dumps core when calling uuid_generate_time_generic
+      CONDA_PACKAGES+=("fiona<1.8.22")
+    fi
+    CONDA_PACKAGES+=('dask-yarn=0.9' "distributed<2022.2")
+  fi
+
+  CONDA_PACKAGES+=(
+    "${cuda_spec}"
+    "rapids=${RAPIDS_VERSION}"
+    "${dask_spec}"
+    "dask-bigquery"
+    "dask-ml"
+    "dask-sql"
+    "cudf"
+    "${numba_spec}"
+  )
+
+  # Install cuda, rapids, dask
+  local is_installed="0"
+  mamba="/opt/conda/miniconda3/bin/mamba"
+  conda="/opt/conda/miniconda3/bin/conda"
+
+  "${conda}" remove -n dask --all || echo "unable to remove conda environment [dask]"
+
+  ( set +e
+  for installer in "${mamba}" "${conda}" ; do
+    test -d "${DASK_CONDA_ENV}" || \
+      time "${installer}" "create" -m -n 'dask-rapids' -y --no-channel-priority \
+      -c 'conda-forge' -c 'nvidia' -c 'rapidsai'  \
+      ${CONDA_PACKAGES[*]} \
+      "${python_spec}"
+    local retval=$?
+    sync
+    if [[ "$retval" == "0" ]] ; then
+      is_installed="1"
+      break
+    fi
+    "${conda}" config --set channel_priority flexible
+  done
+  if [[ "${is_installed}" == "0" ]]; then
+    echo "failed to install dask"
+    return 1
+  fi
+  )
 }
 
 function main() {
-  if [[ "${RAPIDS_RUNTIME}" == "DASK" ]]; then
-    # Install RAPIDS
-    install_dask_rapids
+  # Install Dask with RAPIDS
+  install_dask_rapids
 
-    # In "standalone" mode, Dask relies on a shell script to launch.
-    # In "yarn" mode, it relies a config.yaml file.
-    if [[ "${DASK_RUNTIME}" == "standalone" ]]; then
-      install_systemd_dask_worker
-    elif [[ "${DASK_RUNTIME}" == "yarn" ]]; then
-      configure_dask_yarn
+  # In "standalone" mode, Dask relies on a systemd unit to launch.
+  # In "yarn" mode, it relies a config.yaml file.
+  if [[ "${DASK_RUNTIME}" == "yarn" ]]; then
+    # Create Dask YARN config file
+    configure_dask_yarn
+  elif [[ "${DASK_RUNTIME}" == "standalone" ]]; then
+    # Create Dask service
+    install_systemd_dask_service
+
+    if [[ "$(hostname -s)" == "${MASTER}" ]]; then
+      systemctl start "${DASK_SCHEDULER_SERVICE}"
+      systemctl status "${DASK_SCHEDULER_SERVICE}"
     fi
-    echo "RAPIDS installed with Dask runtime"
+
+    echo "Starting Dask 'standalone' cluster..."
+    if [[ "${enable_worker_service}" == "1" ]]; then
+      systemctl start "${DASK_WORKER_SERVICE}"
+      systemctl status "${DASK_WORKER_SERVICE}"
+    fi
+
+    configure_knox_for_dask
+
+    local DASK_CLOUD_LOGGING="$(get_metadata_attribute dask-cloud-logging || echo 'false')"
+    if [[ "${DASK_CLOUD_LOGGING}" == "true" ]]; then
+      configure_fluentd_for_dask
+    fi
   else
-    echo "Unsupported RAPIDS Runtime: ${RAPIDS_RUNTIME}"
+    echo "Unsupported Dask Runtime: ${DASK_RUNTIME}"
     exit 1
   fi
 
+  echo "Dask RAPIDS for ${DASK_RUNTIME} successfully initialized."
   if [[ "${ROLE}" == "Master" ]]; then
     systemctl restart hadoop-yarn-resourcemanager.service
     # Restart NodeManager on Master as well if this is a single-node-cluster.
@@ -230,8 +534,10 @@ function main() {
   fi
 }
 
-function exit_handler() {
+function exit_handler() (
   set +e
+  echo "Exit handler invoked"
+
   # Free conda cache
   /opt/conda/miniconda3/bin/conda clean -a > /dev/null 2>&1
 
@@ -279,16 +585,44 @@ print( "maximum-disk-used: $max", $/ );' < /tmp/disk-usage.log
   echo "exit_handler has completed"
 
   # zero free disk space
-  if [[ -n "$(get_metadata_attribute 'creating-image')" ]]; then
+  if [[ -n "$(get_metadata_attribute creating-image)" ]]; then
     dd if=/dev/zero of=/zero ; sync ; rm -f /zero
   fi
 
   return 0
-}
+)
 
 trap exit_handler EXIT
 
 function prepare_to_install(){
+  readonly DEFAULT_CUDA_VERSION="12.4"
+  CUDA_VERSION=$(get_metadata_attribute 'cuda-version' ${DEFAULT_CUDA_VERSION})
+  readonly CUDA_VERSION
+
+  readonly ROLE=$(get_metadata_attribute dataproc-role)
+  readonly MASTER=$(get_metadata_attribute dataproc-master)
+
+  # RAPIDS config
+  RAPIDS_RUNTIME=$(get_metadata_attribute 'rapids-runtime' 'DASK')
+  readonly RAPIDS_RUNTIME
+
+  readonly DEFAULT_DASK_RAPIDS_VERSION="24.08"
+  readonly RAPIDS_VERSION=$(get_metadata_attribute 'rapids-version' ${DEFAULT_DASK_RAPIDS_VERSION})
+
+  # Dask config
+  DASK_RUNTIME="$(get_metadata_attribute dask-runtime || echo 'standalone')"
+  readonly DASK_RUNTIME
+  readonly DASK_SERVICE=dask-cluster
+  readonly DASK_WORKER_SERVICE=dask-worker
+  readonly DASK_SCHEDULER_SERVICE=dask-scheduler
+  readonly DASK_CONDA_ENV="/opt/conda/miniconda3/envs/dask-rapids"
+
+  # Knox config
+  readonly KNOX_HOME=/usr/lib/knox
+  readonly KNOX_DASK_DIR="${KNOX_HOME}/data/services/dask/0.1.0"
+  readonly KNOX_DASKWS_DIR="${KNOX_HOME}/data/services/daskws/0.1.0"
+  enable_worker_service="0"
+
   free_mem="$(awk '/^MemFree/ {print $2}' /proc/meminfo)"
   # Write to a ramdisk instead of churning the persistent disk
   if [[ ${free_mem} -ge 5250000 ]]; then

--- a/examples/secure-boot/rapids.sh
+++ b/examples/secure-boot/rapids.sh
@@ -422,7 +422,7 @@ function install_dask_rapids() {
   if is_cuda12 ; then
     local python_spec="python>=3.11"
     local cuda_spec="cuda-version>=12,<13"
-    local dask_spec="dask>=2024.5"
+    local dask_spec="dask>=2024.7"
     local numba_spec="numba"
   elif is_cuda11 ; then
     local python_spec="python>=3.9"

--- a/examples/secure-boot/rapids.sh
+++ b/examples/secure-boot/rapids.sh
@@ -99,7 +99,7 @@ function install_dask_rapids() {
   if is_cuda12 ; then
     local python_spec="python>=3.11"
     local cuda_spec="cuda-version>=12,<13"
-    local dask_spec="dask>=2024.8"
+    local dask_spec="dask>=2024.5"
     local numba_spec="numba"
   elif is_cuda11 ; then
     local python_spec="python>=3.9"
@@ -121,8 +121,8 @@ function install_dask_rapids() {
 
   # Install cuda, rapids, dask
   local is_installed="0"
-  mamba="/opt/conda/default/bin/mamba"
-  conda="/opt/conda/default/bin/conda"
+  mamba="/opt/conda/miniconda3/bin/mamba"
+  conda="/opt/conda/miniconda3/bin/conda"
 
   for installer in "${mamba}" "${conda}" ; do
     set +e
@@ -252,6 +252,7 @@ EOF
 
 function configure_dask_yarn() {
   # Replace config file on cluster.
+  mkdir -p "$(dirname "${DASK_YARN_CONFIG_FILE}")"
   cat <<EOF >"${DASK_YARN_CONFIG_FILE}"
 # Config file for Dask Yarn.
 #
@@ -302,3 +303,5 @@ function main() {
 }
 
 main
+
+df -h

--- a/examples/secure-boot/rapids.sh
+++ b/examples/secure-boot/rapids.sh
@@ -431,7 +431,7 @@ function install_dask_rapids() {
     local numba_spec="numba"
   fi
 
-  rapids_spec="rapids=${RAPIDS_VERSION}"
+  rapids_spec="rapids>=${RAPIDS_VERSION}"
   CONDA_PACKAGES=()
   if [[ "${DASK_RUNTIME}" == 'yarn' ]]; then
     # Pin `distributed` and `dask` package versions to old release
@@ -461,21 +461,20 @@ function install_dask_rapids() {
   )
 
   # Install cuda, rapids, dask
-  local is_installed="0"
   mamba="/opt/conda/miniconda3/bin/mamba"
   conda="/opt/conda/miniconda3/bin/conda"
 
   "${conda}" remove -n dask --all || echo "unable to remove conda environment [dask]"
 
   ( set +e
+  local is_installed="0"
   for installer in "${mamba}" "${conda}" ; do
     test -d "${DASK_CONDA_ENV}" || \
       time "${installer}" "create" -m -n 'dask-rapids' -y --no-channel-priority \
       -c 'conda-forge' -c 'nvidia' -c 'rapidsai'  \
       ${CONDA_PACKAGES[*]} \
       "${python_spec}" \
-      > "${install_log}" 2>&1 || { cat "${install_log}" && exit -4 ; }
-    local retval=$?
+      > "${install_log}" 2>&1 && retval=$? || { retval=$? ; cat "${install_log}" ; }
     sync
     if [[ "$retval" == "0" ]] ; then
       is_installed="1"
@@ -576,7 +575,7 @@ function exit_handler() (
   # Log file contains logs like the following (minus the preceeding #):
 #Filesystem      Size  Used Avail Use% Mounted on
 #/dev/vda2       6.8G  2.5G  4.0G  39% /
-  df -h | tee -a "${tmpdir}/disk-usage.log"
+  df -h / | tee -a "${tmpdir}/disk-usage.log"
   perl -e '$max=( sort
                    map { (split)[2] =~ /^(\d+)/ }
                   grep { m:^/: } <STDIN> )[-1];
@@ -653,7 +652,7 @@ function prepare_to_install(){
   else
       dnf -y -q install screen
   fi
-  df -h | tee "${tmpdir}/disk-usage.log"
+  df -h / | tee "${tmpdir}/disk-usage.log"
   touch "${tmpdir}/keep-running-df"
   screen -d -m -US keep-running-df \
     bash -c "while [[ -f ${tmpdir}/keep-running-df ]] ; do df -h / | tee -a ${tmpdir}/disk-usage.log ; sleep 5s ; done"


### PR DESCRIPTION
custom_image_utils/shell_script_generator.py
* added retry function
* reduced debug output when -x is passed
* reducing buffer for write to startup-script.log

examples/secure-boot/README.md
* re-named the docker images for clarity

examples/secure-boot/build-current-images.sh
* using the same timestamp for all images
* added perl code to disk_usage to extract maximum disk usage during installation
* making request for image and instance list once here instead of each
  time an image is about to be created

examples/secure-boot/install_gpu_driver.sh
* add is_debuntu to simplify common is_debian || is_ubuntu use case
* prepend clean to execute_with_retries to reduce maximum image size
* downloading assets to ram disk to reduce maximum image size
* added sync to key points of the script to allow accurate measurement
  of maximum disk usage
* moved initialization steps to new function prepare_to_install
* created exit_handler function which gets executed before script exits

examples/secure-boot/pre-init.screenrc
* re-ordered versions alphabetically

examples/secure-boot/pre-init.sh
* default to using standalone dask runtime because yarn is getting outdated
* re-using cache of image and instance list from parent script
* increased machine type to accommodate ram disk
* updated disk image sizes based on disk usage analysis
* dask image is no longer intermediate

examples/secure-boot/dask.sh
examples/secure-boot/rapids.sh
* refactored these scripts to be nearly identical
* removed spark-related logic (see spark-rapids)
* remove dask packages if they were installed
* moved initialization steps to new function prepare_to_install
* created exit_handler function which gets executed before script exits

