### PR TITLE
Fix optional-components installation for 2.3+ images.

### DIFF
--- a/custom_image_utils/shell_script_generator.py
+++ b/custom_image_utils/shell_script_generator.py
@@ -36,7 +36,7 @@ function execute_with_retries() (
 
   for ((i = 0; i < 3; i++)); do
     if eval "$cmd"; then return 0 ; fi
-    sleep 5
+    sleep 12
   done
   return 1
 )
@@ -50,7 +50,7 @@ function exit_handler() {{
         --project={project_id} --zone={zone} -q
   elif [[ -f /tmp/{run_id}/disk_created ]]; then
     echo 'Deleting disk.'
-    execute_with_retries gcloud compute ${{base_obj_type}} delete {image_name}-install --project={project_id} --zone={zone} -q
+    execute_with_retries gcloud compute ${{base_obj_type}} delete {image_name}-install --project={project_id} -q
   fi
 
   echo 'Uploading local logs to GCS bucket.'
@@ -221,6 +221,10 @@ function main() {{
 
   echo "Monitor startup logs in {log_dir}/startup-script.log"
   echo 'Waiting for customization script to finish and VM shutdown.'
+
+  # too many serial port output requests per minute occur if they all occur at once
+  sleep $(( ( RANDOM % 60 ) + 20 ))
+
   execute_with_retries gcloud compute instances tail-serial-port-output {image_name}-install \
       --project={project_id} \
       --zone={zone} \

--- a/examples/secure-boot/build-current-images.sh
+++ b/examples/secure-boot/build-current-images.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+# Copyright 2024 Google LLC and contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,9 +14,37 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-# This script creates a custom image pre-loaded with cuda
+# This script creates a custom image pre-loaded with
+#
+# GPU drivers + cuda + rapids + cuDNN + nccl + tensorflow + pytorch + ipykernel + numba
+
+# To run the script, the following will bootstrap
+#
+# git clone git@github.com:GoogleCloudDataproc/custom-images
+# cd custom-images
+# git checkout 2025.02
+# cp examples/secure-boot/env.json.sample env.json
+# vi env.json
+# docker build -f Dockerfile -t custom-images-builder:latest .
+# time docker run -it custom-images-builder:latest bash examples/secure-boot/build-current-images.sh
+
 
 set -ex
+
+function execute_with_retries() (
+  set +x
+  local -r cmd="$*"
+  local install_log="${tmpdir}/install.log"
+
+  for ((i = 0; i < 3; i++)); do
+    set -x
+    eval "$cmd" > "${install_log}" 2>&1 && retval=$? || { retval=$? ; cat "${install_log}" ; }
+    set +x
+    if [[ $retval == 0 ]] ; then return 0 ; fi
+    sleep 5
+  done
+  return 1
+)
 
 function configure_service_account() {
   # Create service account
@@ -30,104 +59,155 @@ function configure_service_account() {
   if [[ -d tls ]] ; then mv tls "tls-$(date +%s)" ; fi
   eval "$(bash examples/secure-boot/create-key-pair.sh)"
 
-  # Grant service account access to bucket
-  gcloud storage buckets add-iam-policy-binding "gs://${BUCKET}" \
+  execute_with_retries gcloud projects add-iam-policy-binding "${PROJECT_ID}" \
     --member="serviceAccount:${GSA}" \
-    --role="roles/storage.objectViewer" > /dev/null 2>&1
+    --role="roles/dataproc.worker" \
+    --condition=None
 
-  # Grant the service account access to list secrets for the project
-  gcloud projects add-iam-policy-binding "${PROJECT_ID}" \
-    --member="serviceAccount:${GSA}" \
-    --role="roles/secretmanager.viewer" > /dev/null 2>&1
+  # Grant the service account access to buckets in this project
+  # TODO: this is over-broad and should be limited only to the buckets
+  # used by these clusters
+  for storage_object_role in 'User' 'Creator' 'Viewer' ; do
+    execute_with_retries gcloud projects add-iam-policy-binding "${PROJECT_ID}" \
+      --member="serviceAccount:${GSA}" \
+      --role="roles/storage.object${storage_object_role}" \
+      --condition=None
+  done
 
-  # Grant service account permission to access the private secret
-  gcloud secrets add-iam-policy-binding "${private_secret_name}" \
-    --member="serviceAccount:${GSA}" \
-    --role="roles/secretmanager.secretAccessor" > /dev/null 2>&1
+  for secret in "${public_secret_name}" "${private_secret_name}" ; do
+    for sm_role in 'viewer' 'secretAccessor' ; do
+      # Grant the service account permission to list the secret
+      execute_with_retries gcloud secrets -q add-iam-policy-binding "${secret}" \
+        --member="serviceAccount:${GSA}" \
+        --role="roles/secretmanager.${sm_role}" \
+        --condition=None
+    done
+  done
 
-  # Grant service account permission to access the public secret
-  gcloud secrets add-iam-policy-binding "${public_secret_name}" \
+  execute_with_retries gcloud projects add-iam-policy-binding "${PROJECT_ID}" \
     --member="serviceAccount:${GSA}" \
-    --role="roles/secretmanager.secretAccessor" > /dev/null 2>&1
+    --role=roles/compute.instanceAdmin.v1 \
+    --condition=None
+
+  execute_with_retries gcloud iam service-accounts add-iam-policy-binding "${GSA}" \
+    --member="serviceAccount:${GSA}" \
+    --role=roles/iam.serviceAccountUser \
+    --condition=None
 }
 
 function revoke_bindings() {
-  # Revoke permission to access the private secret
-  gcloud secrets remove-iam-policy-binding "${private_secret_name}" \
+  execute_with_retries gcloud projects remove-iam-policy-binding "${PROJECT_ID}" \
     --member="serviceAccount:${GSA}" \
-    --role="roles/secretmanager.secretAccessor" > /dev/null 2>&1
+    --role="roles/dataproc.worker" \
+    --condition=None
 
-  # Revoke access to bucket
-  gcloud storage buckets remove-iam-policy-binding "gs://${BUCKET}" \
-    --member="serviceAccount:${GSA}" \
-    --role="roles/storage.objectViewer" > /dev/null 2>&1
+  # Revoke the service account's access to buckets in this project
+  for storage_object_role in 'User' 'Creator' 'Viewer' ; do
+    execute_with_retries gcloud projects remove-iam-policy-binding "${PROJECT_ID}" \
+      --member="serviceAccount:${GSA}" \
+      --role="roles/storage.object${storage_object_role}" \
+      --condition=None
+  done
 
-  # Revoke access to list secrets for the project
-  gcloud projects remove-iam-policy-binding "${PROJECT_ID}" \
+  for secret in "${public_secret_name}" "${private_secret_name}" ; do
+    # Revoke the service account's permission to list and access the secret
+    for sm_role in 'viewer' 'secretAccessor' ; do
+      execute_with_retries gcloud secrets -q remove-iam-policy-binding "${secret}" \
+        --member="serviceAccount:${GSA}" \
+        --role="roles/secretmanager.${sm_role}" \
+        --condition=None
+    done
+  done
+
+  execute_with_retries gcloud projects remove-iam-policy-binding "${PROJECT_ID}" \
     --member="serviceAccount:${GSA}" \
-    --role="roles/secretmanager.viewer" > /dev/null 2>&1
+    --role=roles/compute.instanceAdmin.v1 \
+    --condition=None
+
+  execute_with_retries gcloud iam service-accounts remove-iam-policy-binding "${GSA}" \
+    --member="serviceAccount:${GSA}" \
+    --role=roles/iam.serviceAccountUser \
+    --condition=None
 }
 
-export PROJECT_ID="$(jq    -r .PROJECT_ID    env.json)"
-export PURPOSE="$(jq       -r .PURPOSE       env.json)"
-export BUCKET="$(jq        -r .BUCKET        env.json)"
 
-SA_NAME="sa-${PURPOSE}"
-GSA="${SA_NAME}@${PROJECT_ID}.iam.gserviceaccount.com"
+export DOMAIN="$(jq           -r .DOMAIN        env.json)"
+export PROJECT_ID="$(jq       -r .PROJECT_ID    env.json)"
+export PURPOSE="$(jq          -r .PURPOSE       env.json)"
+export BUCKET="$(jq           -r .BUCKET        env.json)"
+export SECRET_NAME="$(jq      -r .SECRET_NAME   env.json)"
+export REGION="$(jq           -r .REGION        env.json)"
+export ZONE="$(jq             -r .ZONE          env.json)"
+export PRINCIPAL_USER="$(jq   -r .PRINCIPAL     env.json)"
+export PRINCIPAL_DOMAIN="$(jq -r .DOMAIN        env.json)"
+export PRINCIPAL="${PRINCIPAL_USER}@${PRINCIPAL_DOMAIN}"
 
-gcloud config set project "${PROJECT_ID}"
+echo -n "setting gcloud config..."
+CURRENT_ACCOUNT="$(gcloud config get account)"
+if [[ "${CURRENT_ACCOUNT}" != "${PRINCIPAL}" ]]; then
+    echo "setting gcloud account"
+    gcloud config set account "${PRINCIPAL}"
+fi
+CURRENT_PROJECT_ID="$(gcloud config get project)"
+if [[ "${CURRENT_PROJECT_ID}" != "${PROJECT_ID}" ]]; then
+    echo "setting gcloud project"
+    gcloud config set project ${PROJECT_ID}
+fi
 
 gcloud auth login
+
+CURRENT_COMPUTE_REGION="$(gcloud config get compute/region)"
+if [[ "${CURRENT_COMPUTE_REGION}" != "${REGION}" ]]; then
+    echo "setting compute region"
+    gcloud config set compute/region "${REGION}"
+fi
+CURRENT_DATAPROC_REGION="$(gcloud config get dataproc/region)"
+if [[ "${CURRENT_DATAPROC_REGION}" != "${REGION}" ]]; then
+    echo "setting dataproc region"
+    gcloud config set dataproc/region "${REGION}"
+fi
+CURRENT_COMPUTE_ZONE="$(gcloud config get compute/zone)"
+if [[ "${CURRENT_COMPUTE_ZONE}" != "${ZONE}" ]]; then
+    echo "setting compute zone"
+    gcloud config set compute/zone "${ZONE}"
+fi
+SA_NAME="sa-${PURPOSE}"
+GSA="${SA_NAME}@${PROJECT_ID}.iam.gserviceaccount.com"
+if [[ "${PROJECT_ID}" =~ ":" ]] ; then
+  GSA="${SA_NAME}@${PROJECT_ID#*:}.${PROJECT_ID%:*}.iam.gserviceaccount.com"
+else
+   GSA="${SA_NAME}@${PROJECT_ID}.iam.gserviceaccount.com"
+fi
+
+readonly timestamp="$(date "+%Y%m%d-%H%M%S")"
+#readonly timestamp="$(date +%F-%H-%M)"
+#readonly timestamp="2025-04-15-23-04"
+export timestamp
+
+export tmpdir=/tmp/${timestamp};
+mkdir -p ${tmpdir}
 
 configure_service_account
 
 # screen session name
 session_name="build-current-images"
 
-readonly timestamp="$(date +%F-%H-%M)"
-#readonly timestamp="2024-10-24-04-21"
-export timestamp
-
-export tmpdir=/tmp/${timestamp};
-mkdir ${tmpdir}
 export ZONE="$(jq -r .ZONE env.json)"
 gcloud compute instances list --zones "${ZONE}" --format json > ${tmpdir}/instances.json
 gcloud compute images    list                   --format json > ${tmpdir}/images.json
 
 # Run generation scripts simultaneously for each dataproc image version
-screen -US "${session_name}" -c examples/secure-boot/pre-init.screenrc
+screen -L -US "${session_name}" -c examples/secure-boot/pre-init.screenrc
 
-# tail -n 3 /tmp/custom-image-*/logs/workflow.log
-# tail -n 3 /tmp/custom-image-*/logs/startup-script.log
-# tail -n 3 /tmp/custom-image-${PURPOSE}-2-*/logs/workflow.log
 function find_disk_usage() {
-  test -f /tmp/genline.pl || cat > /tmp/genline.pl<<'EOF'
-#!/usr/bin/perl -w
-use strict;
-
-my $fn = $ARGV[0];
-my( $config ) = ( $fn =~ /custom-image-(.*-(debian|rocky|ubuntu)\d+)-\d+/ );
-
-my @raw_lines = <STDIN>;
-my( $l ) = grep { m: /dev/.*/\s*$: } @raw_lines;
-my( $stats ) = ( $l =~ m:\s*/dev/\S+\s+(.*?)\s*$: );
-
-my( $dp_version ) = ($config =~ /-pre-init-(.+)/);
-$dp_version =~ s/-/./;
-
-my($max) = map { / maximum-disk-used: (\d+)/ } @raw_lines;
-$max+=3;
-my $i_dp_version = sprintf(q{%-15s}, qq{"$dp_version"});
-
-print( qq{  $i_dp_version) disk_size_gb="$max" ;; # $stats # $config}, $/ );
-EOF
-  for f in $(grep -l 'Customization script suc' /tmp/custom-image-*/logs/workflow.log|sed -e 's/workflow.log/startup-script.log/')
-  do
-    grep -A20 'Filesystem.*Avail' $f | perl /tmp/genline.pl $f
+  #  grep maximum-disk-used /tmp/custom-image-*/logs/startup-script.log
+  grep -H 'Customization script' /tmp/custom-image-*/logs/workflow.log
+  for workflow_log in $(grep -Hl "Customization script" /tmp/custom-image-*/logs/workflow.log) ; do
+    startup_log=$(echo "${workflow_log}" | sed -e 's/workflow.log/startup-script.log/')
+    grep -v '^\['  "${startup_log}" \
+      | grep -A7 'Filesystem.*Avail' \
+      | perl examples/secure-boot/genline.pl "${workflow_log}"
   done
 }
-
-# sleep 8m ; grep 'Customization script' /tmp/custom-image-*/logs/workflow.log
-# grep maximum-disk-used /tmp/custom-image-*/logs/startup-script.log
 
 revoke_bindings

--- a/examples/secure-boot/pre-init.screenrc
+++ b/examples/secure-boot/pre-init.screenrc
@@ -4,14 +4,20 @@
 
 # screen -L -t monitor 0 /bin/bash
 
-screen -L -t 2.0-debian10 1 /bin/bash -x examples/secure-boot/pre-init.sh 2.0-debian10
-screen -L -t 2.0-rocky8   2 /bin/bash -x examples/secure-boot/pre-init.sh 2.0-rocky8
-screen -L -t 2.0-ubuntu18 3 /bin/bash -x examples/secure-boot/pre-init.sh 2.0-ubuntu18
+#screen -L -t 1.5-debian10  1 /bin/bash -x examples/secure-boot/pre-init.sh 1.5-debian10
 
-screen -L -t 2.1-debian11 4 /bin/bash -x examples/secure-boot/pre-init.sh 2.1-debian11
-screen -L -t 2.1-rocky8   5 /bin/bash -x examples/secure-boot/pre-init.sh 2.1-rocky8
-screen -L -t 2.1-ubuntu20 6 /bin/bash -x examples/secure-boot/pre-init.sh 2.1-ubuntu20
+screen -L -t 2.0-debian10  2 /bin/bash -x examples/secure-boot/pre-init.sh 2.0-debian10
+screen -L -t 2.0-rocky8    3 /bin/bash -x examples/secure-boot/pre-init.sh 2.0-rocky8
+screen -L -t 2.0-ubuntu18  4 /bin/bash -x examples/secure-boot/pre-init.sh 2.0-ubuntu18
 
-screen -L -t 2.2-debian12 7 /bin/bash -x examples/secure-boot/pre-init.sh 2.2-debian12
-screen -L -t 2.2-rocky9   8 /bin/bash -x examples/secure-boot/pre-init.sh 2.2-rocky9
-screen -L -t 2.2-ubuntu22 9 /bin/bash -x examples/secure-boot/pre-init.sh 2.2-ubuntu22
+screen -L -t 2.1-debian11  5 /bin/bash -x examples/secure-boot/pre-init.sh 2.1-debian11
+screen -L -t 2.1-rocky8    6 /bin/bash -x examples/secure-boot/pre-init.sh 2.1-rocky8
+screen -L -t 2.1-ubuntu20  7 /bin/bash -x examples/secure-boot/pre-init.sh 2.1-ubuntu20
+
+screen -L -t 2.2-debian12  8 /bin/bash -x examples/secure-boot/pre-init.sh 2.2-debian12
+screen -L -t 2.2-rocky9    9 /bin/bash -x examples/secure-boot/pre-init.sh 2.2-rocky9
+screen -L -t 2.2-ubuntu22 10 /bin/bash -x examples/secure-boot/pre-init.sh 2.2-ubuntu22
+
+screen -L -t 2.3-debian12 11 /bin/bash -x examples/secure-boot/pre-init.sh 2.3-debian12
+screen -L -t 2.3-rocky9   12 /bin/bash -x examples/secure-boot/pre-init.sh 2.3-rocky9
+screen -L -t 2.3-ubuntu22 13 /bin/bash -x examples/secure-boot/pre-init.sh 2.3-ubuntu22

--- a/examples/secure-boot/pre-init.sh
+++ b/examples/secure-boot/pre-init.sh
@@ -20,11 +20,25 @@ set -e
 
 IMAGE_VERSION="$1"
 if [[ -z "${IMAGE_VERSION}" ]] ; then
-export IMAGE_VERSION="$(jq -r .IMAGE_VERSION        env.json)" ; fi
-export PROJECT_ID="$(jq    -r .PROJECT_ID           env.json)"
-export PURPOSE="$(jq       -r .PURPOSE              env.json)"
-export BUCKET="$(jq        -r .BUCKET               env.json)"
-export ZONE="$(jq          -r .ZONE                 env.json)"
+IMAGE_VERSION="$(jq    -r .IMAGE_VERSION        env.json)" ; fi
+PROJECT_ID="$(jq       -r .PROJECT_ID           env.json)"
+PURPOSE="$(jq          -r .PURPOSE              env.json)"
+BUCKET="$(jq           -r .BUCKET               env.json)"
+TEMP_BUCKET="$(jq      -r .TEMP_BUCKET          env.json)"
+ZONE="$(jq             -r .ZONE                 env.json)"
+SUBNET="$(jq           -r .SUBNET               env.json)"
+HIVE_NAME="$(jq        -r .HIVE_INSTANCE_NAME   env.json)"
+HIVEDB_PW_URI="$(jq    -r .DB_HIVE_PASSWORD_URI env.json)"
+SECRET_NAME="$(jq      -r .SECRET_NAME          env.json)"
+KMS_KEY_URI="$(jq      -r .KMS_KEY_URI          env.json)"
+
+PRINCIPAL_USER="$(jq   -r .PRINCIPAL            env.json)"
+PRINCIPAL_DOMAIN="$(jq -r .DOMAIN               env.json)"
+PRINCIPAL="${PRINCIPAL_USER}@${PRINCIPAL_DOMAIN}"
+gcloud config set project "${PROJECT_ID}"
+gcloud config set account "${PRINCIPAL}"
+
+region="$(echo "${ZONE}" | perl -pe 's/-[a-z]+$//')"
 
 custom_image_zone="${ZONE}"
 disk_size_gb="30" # greater than or equal to 30
@@ -32,18 +46,6 @@ disk_size_gb="30" # greater than or equal to 30
 SA_NAME="sa-${PURPOSE}"
 GSA="${SA_NAME}@${PROJECT_ID}.iam.gserviceaccount.com"
 
-gcloud config set project ${PROJECT_ID}
-
-#gcloud auth login
-
-eval "$(bash examples/secure-boot/create-key-pair.sh)"
-metadata="public_secret_name=${public_secret_name}"
-metadata="${metadata},private_secret_name=${private_secret_name}"
-metadata="${metadata},secret_project=${secret_project}"
-metadata="${metadata},secret_version=${secret_version}"
-metadata="${metadata},dask-runtime=standalone"
-metadata="${metadata},rapids-runtime=DASK"
-metadata="${metadata},cuda-version=12.4"
 
 # If no OS family specified, default to debian
 if [[ "${IMAGE_VERSION}" != *-* ]] ; then
@@ -52,14 +54,60 @@ if [[ "${IMAGE_VERSION}" != *-* ]] ; then
     "2.2" ) dataproc_version="${IMAGE_VERSION}-debian12" ;;
     "2.1" ) dataproc_version="${IMAGE_VERSION}-debian11" ;;
     "2.0" ) dataproc_version="${IMAGE_VERSION}-debian10" ;;
+    "1.5" ) dataproc_version="${IMAGE_VERSION}-debian10" ;;
   esac
 else
   dataproc_version="${IMAGE_VERSION}"
 fi
 
+CUDA_VERSION="12.4.1"
+case "${dataproc_version}" in
+  "1.5-debian10" ) CUDA_VERSION="11.5.2" ; short_dp_ver=1.5-deb10 ;;
+  "2.0-debian10" ) CUDA_VERSION="12.1.1" ; short_dp_ver=2.0-deb10 ;;
+  "2.0-rocky8"   ) CUDA_VERSION="12.1.1" ; short_dp_ver=2.0-roc8 ;;
+  "2.0-ubuntu18" ) CUDA_VERSION="12.1.1" ; short_dp_ver=2.0-ubu18 ;;
+  "2.1-debian11" ) CUDA_VERSION="12.4.1" ; short_dp_ver=2.1-deb11 ;;
+  "2.1-rocky8"   ) CUDA_VERSION="12.4.1" ; short_dp_ver=2.1-roc8 ;;
+  "2.1-ubuntu20" ) CUDA_VERSION="12.4.1" ; short_dp_ver=2.1-ubu20 ;;
+  "2.2-debian12" ) CUDA_VERSION="12.6.3" ; short_dp_ver=2.2-deb12 ;;
+  "2.2-rocky9"   ) CUDA_VERSION="12.6.3" ; short_dp_ver=2.2-roc9 ;;
+  "2.2-ubuntu22" ) CUDA_VERSION="12.6.3" ; short_dp_ver=2.2-ubu22 ;;
+  "2.3-debian12" ) CUDA_VERSION="12.6.3" ; short_dp_ver=2.3-deb12 ;;
+  "2.3-rocky9"   ) CUDA_VERSION="12.6.3" ; short_dp_ver=2.3-roc9 ;;
+  "2.3-ubuntu22" ) CUDA_VERSION="12.6.3" ; short_dp_ver=2.3-ubu22 ;;
+esac
+
+eval "$(bash examples/secure-boot/create-key-pair.sh)"
+metadata="rapids-runtime=SPARK"
+metadata="${metadata},cuda-version=${CUDA_VERSION}"
+metadata="${metadata},invocation-type=custom-images"
+metadata="${metadata},dataproc-temp-bucket=${TEMP_BUCKET}"
+metadata="${metadata},include-pytorch=1"
+
+function create_h100_instance() {
+  python generate_custom_image.py \
+    --machine-type         "a3-highgpu-2g" \
+    --accelerator          "type=nvidia-h100-80gb,count=2" \
+    $*
+}
+
+function create_t4_instance() {
+  python generate_custom_image.py \
+    --machine-type         "n1-standard-32" \
+    --accelerator          "type=nvidia-tesla-t4,count=1" \
+    $*
+}
+
+function create_unaccelerated_instance() {
+  python generate_custom_image.py \
+    --machine-type         "n1-standard-32" \
+    $*
+}
+
 function generate() {
   local extra_args="$*"
-  local image_name="${PURPOSE}-${dataproc_version/\./-}-${timestamp}"
+#  local image_name="${PURPOSE}-${timestamp}-${dataproc_version//\./-}"
+  local image_name="dataproc-${short_dp_ver//\./-}-${timestamp}-${PURPOSE}"
 
   local image="$(jq -r ".[] | select(.name == \"${image_name}\").name" "${tmpdir}/images.json")"
 
@@ -68,18 +116,33 @@ function generate() {
     return
   fi
 
+  local install_image="$(jq -r ".[] | select(.name == \"${image_name}-install\").name" "${tmpdir}/images.json")"
+  if [[ -n "${install_image}" ]] ; then
+    echo "Install image already exists.  Cleaning up after aborted run."
+    gcloud -q compute images delete "${image_name}-install"
+  fi
+
   local instance="$(jq -r ".[] | select(.name == \"${image_name}-install\").name" "${tmpdir}/instances.json")"
 
   if [[ -n "${instance}" ]]; then
     # if previous run ended without cleanup...
     echo "cleaning up instance from previous run"
-    gcloud -q compute instances delete "${image_name}-install" \
-      --zone "${custom_image_zone}"
+    gcloud -q compute instances delete "${image_name}-install"
   fi
+
+  create_function="create_t4_instance"
+
+  if [[ "${customization_script}" =~ "cloud-sql-proxy.sh" \
+     || "${customization_script}" =~ "dask.sh" \
+     || "${customization_script}" =~ "no-customization.sh" ]] ; then
+    metadata="${metadata},hive-metastore-instance=${PROJECT_ID}:${region}:${HIVE_NAME}"
+    metadata="${metadata},db-hive-password-uri=${HIVEDB_PW_URI}"
+    metadata="${metadata},kms-key-uri=${KMS_KEY_URI}"
+    create_function="create_unaccelerated_instance"
+  fi
+
   set -xe
-  python generate_custom_image.py \
-    --machine-type         "n1-standard-8" \
-    --accelerator          "type=nvidia-tesla-t4" \
+  "${create_function}" \
     --image-name           "${image_name}" \
     --customization-script "${customization_script}" \
     --service-account      "${GSA}" \
@@ -87,6 +150,8 @@ function generate() {
     --zone                 "${custom_image_zone}" \
     --disk-size            "${disk_size_gb}" \
     --gcs-bucket           "${BUCKET}" \
+    --subnet               "${SUBNET}" \
+    --optional-components  "DOCKER,PIG" \
     --shutdown-instance-timer-sec=30 \
     --no-smoke-test \
     ${extra_args}
@@ -95,55 +160,120 @@ function generate() {
 
 function generate_from_dataproc_version() { generate --dataproc-version "$1" ; }
 
+function generate_from_prerelease_version() {
+  # base image -> tensorflow
+  local img_pfx="https://www.googleapis.com/compute/v1/projects/cloud-dataproc/global/images"
+  local src_timestamp="20250410-165100"
+  case "${dataproc_version}" in
+#    "1.5-debian10" ) image_uri="${img_pfx}/dataproc-1-5-deb10-${src_timestamp}-rc01"  ;;
+    "2.0-debian10" ) image_uri="${img_pfx}/dataproc-2-0-deb10-${src_timestamp}-rc01"  ;;
+    "2.0-rocky8"   ) image_uri="${img_pfx}/dataproc-2-0-roc8-${src_timestamp}-rc01"   ;;
+    "2.0-ubuntu18" ) image_uri="${img_pfx}/dataproc-2-0-ubu18-${src_timestamp}-rc01"  ;;
+    "2.1-debian11" ) image_uri="${img_pfx}/dataproc-2-1-deb11-${src_timestamp}-rc01"  ;;
+    "2.1-rocky8"   ) image_uri="${img_pfx}/dataproc-2-1-roc8-${src_timestamp}-rc01"   ;;
+    "2.1-ubuntu20" ) image_uri="${img_pfx}/dataproc-2-1-ubu20-${src_timestamp}-rc01"  ;;
+    "2.2-debian12" ) image_uri="${img_pfx}/dataproc-2-2-deb12-${src_timestamp}-rc01"  ;;
+    "2.2-rocky9"   ) image_uri="${img_pfx}/dataproc-2-2-roc9-${src_timestamp}-rc01"   ;;
+    "2.2-ubuntu22" ) image_uri="${img_pfx}/dataproc-2-2-ubu22-${src_timestamp}-rc01"  ;;
+    "2.3-debian12" ) image_uri="${img_pfx}/dataproc-2-3-deb12-${src_timestamp}-rc01"  ;;
+    "2.3-rocky9"   ) image_uri="${img_pfx}/dataproc-2-3-roc9-${src_timestamp}-rc01"   ;;
+    "2.3-ubuntu22" ) image_uri="${img_pfx}/dataproc-2-3-ubu22-${src_timestamp}-rc01"  ;;
+  esac
+  generate --base-image-uri "${image_uri}"
+}
+
 function generate_from_base_purpose() {
   generate --base-image-uri "https://www.googleapis.com/compute/v1/projects/${PROJECT_ID}/global/images/${1}-${dataproc_version/\./-}-${timestamp}"
 }
 
-# base image -> cuda
+# base image -> tensorflow
+disk_size_gb="42"
 case "${dataproc_version}" in
-  "2.0-debian10" ) disk_size_gb="38" ;; # 40G   31G  7.8G  80% / # cuda-pre-init-2-0-debian10
-  "2.0-rocky8"   ) disk_size_gb="35" ;; # 38G   32G  6.2G  84% / # cuda-pre-init-2-0-rocky8
-  "2.0-ubuntu18" ) disk_size_gb="37" ;; # 39G   30G  8.5G  79% / # cuda-pre-init-2-0-ubuntu18
-  "2.1-debian11" ) disk_size_gb="37" ;; # 39G   34G  4.1G  90% / # cuda-pre-init-2-1-debian11
-  "2.1-rocky8"   ) disk_size_gb="38" ;; # 41G   35G  6.1G  86% / # cuda-pre-init-2-1-rocky8
-  "2.1-ubuntu20" ) disk_size_gb="35" ;; # 37G   32G  4.4G  88% / # cuda-pre-init-2-1-ubuntu20
-  "2.2-debian12" ) disk_size_gb="38" ;; # 40G   35G  3.3G  92% / # cuda-pre-init-2-2-debian12
-  "2.2-rocky9"   ) disk_size_gb="40" ;; # 42G   36G  5.9G  86% / # cuda-pre-init-2-2-rocky9
-  "2.2-ubuntu22" ) disk_size_gb="38" ;; # 40G   35G  4.8G  88% / # cuda-pre-init-2-2-ubuntu22
-  "2.3-debian12" ) disk_size_gb="38" ;; # 40G   35G  3.3G  92% / # cuda-pre-init-2-3-debian12
-  "2.3-rocky9"   ) disk_size_gb="40" ;; # 42G   36G  5.9G  86% / # cuda-pre-init-2-3-rocky9
-  "2.3-ubuntu22" ) disk_size_gb="38" ;; # 40G   35G  4.8G  88% / # cuda-pre-init-2-3-ubuntu22
+  "1.5-debian10" ) disk_size_gb="42" ;; #
+  "2.0-debian10" ) disk_size_gb="42" ;; #  41.11G  36.28G     3.04G  93% / # tf-pre-init
+  "2.0-rocky8"   ) disk_size_gb="45" ;; #  44.79G  38.43G     6.36G  86% / # tf-pre-init
+  "2.0-ubuntu18" ) disk_size_gb="41" ;; #  39.55G  35.39G     4.14G  90% / # tf-pre-init
+  "2.1-debian11" ) disk_size_gb="46" ;; #  45.04G  39.31G     3.78G  92% / # tf-pre-init
+  "2.1-rocky8"   ) disk_size_gb="48" ;; #  48.79G  41.73G     7.06G  86% / # tf-pre-init
+  "2.1-ubuntu20" ) disk_size_gb="46" ;; #  44.40G  39.92G     4.46G  90% / # tf-pre-init
+  "2.2-debian12" ) disk_size_gb="47" ;; #  46.03G  40.76G     3.28G  93% / # tf-pre-init
+  "2.2-rocky9"   ) disk_size_gb="47" ;; #  46.79G  40.86G     5.93G  88% / # tf-pre-init
+  "2.2-ubuntu22" ) disk_size_gb="47" ;; #  45.37G  40.56G     4.79G  90% / # tf-pre-init
+  "2.3-debian12" ) disk_size_gb="42" ;;
+  "2.3-rocky9"   ) disk_size_gb="42" ;;
+  "2.3-ubuntu22" ) disk_size_gb="42" ;;
 esac
 
-# Install GPU drivers + cuda on dataproc base image
-PURPOSE="cuda-pre-init"
+#disk_size_gb="60" # greater than or equal to 40
+
+# Install secure-boot certs without customization
+PURPOSE="secure-boot"
+customization_script="examples/secure-boot/no-customization.sh"
+#time generate_from_dataproc_version "${dataproc_version}"
+
+time generate_from_prerelease_version "${dataproc_version}"
+
+# Install GPU drivers + cuda + rapids + cuDNN + nccl + tensorflow + pytorch on dataproc base image
+PURPOSE="tf"
 customization_script="examples/secure-boot/install_gpu_driver.sh"
-time generate_from_dataproc_version "${dataproc_version}"
+time generate_from_base_purpose "secure-boot"
+
+## Execute spark-rapids/spark-rapids.sh init action on base image
+PURPOSE="spark"
+customization_script="examples/secure-boot/spark-rapids.sh"
+echo time generate_from_base_purpose "tf"
+
+## Execute spark-rapids/spark-rapids.sh init action on base image
+PURPOSE="cloud-sql-proxy"
+customization_script="examples/secure-boot/cloud-sql-proxy.sh"
+time generate_from_base_purpose "secure-boot"
+
+## Execute spark-rapids/mig.sh init action on base image
+PURPOSE="mig-pre-init"
+customization_script="examples/secure-boot/mig.sh"
+echo time generate_from_base_purpose "tf"
 
 # cuda image -> rapids
 case "${dataproc_version}" in
-  "2.0-debian10" ) disk_size_gb="44" ;; # 47G   41G  4.0G  91% / # rapids-pre-init-2-0-debian10
-  "2.0-rocky8"   ) disk_size_gb="45" ;; # 49G   42G  7.0G  86% / # rapids-pre-init-2-0-rocky8
-  "2.0-ubuntu18" ) disk_size_gb="43" ;; # 45G   40G  4.9G  90% / # rapids-pre-init-2-0-ubuntu18
-  "2.1-debian11" ) disk_size_gb="46" ;; # 49G   43G  3.6G  93% / # rapids-pre-init-2-1-debian11
-  "2.1-rocky8"   ) disk_size_gb="48" ;; # 52G   45G  7.2G  87% / # rapids-pre-init-2-1-rocky8
-  "2.1-ubuntu20" ) disk_size_gb="45" ;; # 47G   42G  5.2G  89% / # rapids-pre-init-2-1-ubuntu20
-  "2.2-debian12" ) disk_size_gb="48" ;; # 51G   45G  3.8G  93% / # rapids-pre-init-2-2-debian12
-  "2.2-rocky9"   ) disk_size_gb="49" ;; # 53G   46G  7.2G  87% / # rapids-pre-init-2-2-rocky9
-  "2.2-ubuntu22" ) disk_size_gb="48" ;; # 50G   45G  5.6G  89% / # rapids-pre-init-2-2-ubuntu22
-  "2.3-debian12" ) disk_size_gb="48" ;; # 51G   45G  3.8G  93% / # rapids-pre-init-2-3-debian12
-  "2.3-rocky9"   ) disk_size_gb="49" ;; # 53G   46G  7.2G  87% / # rapids-pre-init-2-3-rocky9
-  "2.3-ubuntu22" ) disk_size_gb="48" ;; # 50G   45G  5.6G  89% / # rapids-pre-init-2-3-ubuntu22
+  "2.0-debian10" ) disk_size_gb="41" ;; # 40.12G 37.51G   0.86G  98% / # rapids-pre-init-2-0-debian10
+  "2.0-rocky8"   ) disk_size_gb="41" ;; # 38.79G 38.04G   0.76G  99% / # rapids-pre-init-2-0-rocky8
+  "2.0-ubuntu18" ) disk_size_gb="40" ;; # 37.62G 36.69G   0.91G  98% / # rapids-pre-init-2-0-ubuntu18
+  "2.1-debian11" ) disk_size_gb="44" ;; # 42.09G 39.77G   0.49G  99% / # rapids-pre-init-2-1-debian11
+  "2.1-rocky8"   ) disk_size_gb="44" ;; # 43.79G 41.11G   2.68G  94% / # rapids-pre-init-2-1-rocky8
+  "2.1-ubuntu20" ) disk_size_gb="45" ;; # 39.55G 39.39G   0.15G 100% / # rapids-pre-init-2-1-ubuntu20
+  "2.2-debian12" ) disk_size_gb="46" ;; # 44.06G 41.73G   0.41G 100% / # rapids-pre-init-2-2-debian12
+  "2.2-rocky9"   ) disk_size_gb="45" ;; # 44.79G 42.29G   2.51G  95% / # rapids-pre-init-2-2-rocky9
+  "2.2-ubuntu22" ) disk_size_gb="46" ;; # 42.46G 41.97G   0.48G  99% / # rapids-pre-init-2-2-ubuntu22
 esac
 
-#disk_size_gb="50"
+#disk_size_gb="45"
 
 # Install dask with rapids on base image
 PURPOSE="rapids-pre-init"
 customization_script="examples/secure-boot/rapids.sh"
-time generate_from_base_purpose "cuda-pre-init"
+time generate_from_base_purpose "tf-pre-init"
+#time generate_from_base_purpose "cuda-pre-init"
 
-# Install dask without rapids on base image
+## Install dask without rapids on base image
 PURPOSE="dask-pre-init"
 customization_script="examples/secure-boot/dask.sh"
-time generate_from_base_purpose "cuda-pre-init"
+time generate_from_base_purpose "secure-boot"
+#time generate_from_base_purpose "cuda-pre-init"
+
+# cuda image -> pytorch
+case "${dataproc_version}" in
+  "2.0-debian10" ) disk_size_gb="44" ;; # 40.12G 37.51G   0.86G  98% / # pre-init-2-0-debian10
+  "2.0-rocky8"   ) disk_size_gb="41" ;; # 38.79G 38.04G   0.76G  99% / # pre-init-2-0-rocky8
+  "2.0-ubuntu18" ) disk_size_gb="44" ;; # 37.62G 36.69G   0.91G  98% / # pre-init-2-0-ubuntu18
+  "2.1-debian11" ) disk_size_gb="44" ;; # 42.09G 39.77G   0.49G  99% / # pre-init-2-1-debian11
+  "2.1-rocky8"   ) disk_size_gb="44" ;; # 43.79G 41.11G   2.68G  94% / # pre-init-2-1-rocky8
+  "2.1-ubuntu20" ) disk_size_gb="45" ;; # 39.55G 39.39G   0.15G 100% / # pre-init-2-1-ubuntu20
+  "2.2-debian12" ) disk_size_gb="48" ;; # 44.06G 41.73G   0.41G 100% / # pre-init-2-2-debian12
+  "2.2-rocky9"   ) disk_size_gb="45" ;; # 44.79G 42.29G   2.51G  95% / # pre-init-2-2-rocky9
+  "2.2-ubuntu22" ) disk_size_gb="46" ;; # 42.46G 41.97G   0.48G  99% / # pre-init-2-2-ubuntu22
+esac
+
+## Install pytorch on base image
+PURPOSE="pytorch-pre-init"
+customization_script="examples/secure-boot/pytorch.sh"
+#time generate_from_base_purpose "cuda-pre-init"

--- a/examples/secure-boot/pre-init.sh
+++ b/examples/secure-boot/pre-init.sh
@@ -48,6 +48,7 @@ metadata="${metadata},cuda-version=12.4"
 # If no OS family specified, default to debian
 if [[ "${IMAGE_VERSION}" != *-* ]] ; then
   case "${IMAGE_VERSION}" in
+    "2.3" ) dataproc_version="${IMAGE_VERSION}-debian12" ;;
     "2.2" ) dataproc_version="${IMAGE_VERSION}-debian12" ;;
     "2.1" ) dataproc_version="${IMAGE_VERSION}-debian11" ;;
     "2.0" ) dataproc_version="${IMAGE_VERSION}-debian10" ;;
@@ -109,6 +110,9 @@ case "${dataproc_version}" in
   "2.2-debian12" ) disk_size_gb="38" ;; # 40G   35G  3.3G  92% / # cuda-pre-init-2-2-debian12
   "2.2-rocky9"   ) disk_size_gb="40" ;; # 42G   36G  5.9G  86% / # cuda-pre-init-2-2-rocky9
   "2.2-ubuntu22" ) disk_size_gb="38" ;; # 40G   35G  4.8G  88% / # cuda-pre-init-2-2-ubuntu22
+  "2.3-debian12" ) disk_size_gb="38" ;; # 40G   35G  3.3G  92% / # cuda-pre-init-2-3-debian12
+  "2.3-rocky9"   ) disk_size_gb="40" ;; # 42G   36G  5.9G  86% / # cuda-pre-init-2-3-rocky9
+  "2.3-ubuntu22" ) disk_size_gb="38" ;; # 40G   35G  4.8G  88% / # cuda-pre-init-2-3-ubuntu22
 esac
 
 # Install GPU drivers + cuda on dataproc base image
@@ -127,6 +131,9 @@ case "${dataproc_version}" in
   "2.2-debian12" ) disk_size_gb="48" ;; # 51G   45G  3.8G  93% / # rapids-pre-init-2-2-debian12
   "2.2-rocky9"   ) disk_size_gb="49" ;; # 53G   46G  7.2G  87% / # rapids-pre-init-2-2-rocky9
   "2.2-ubuntu22" ) disk_size_gb="48" ;; # 50G   45G  5.6G  89% / # rapids-pre-init-2-2-ubuntu22
+  "2.3-debian12" ) disk_size_gb="48" ;; # 51G   45G  3.8G  93% / # rapids-pre-init-2-3-debian12
+  "2.3-rocky9"   ) disk_size_gb="49" ;; # 53G   46G  7.2G  87% / # rapids-pre-init-2-3-rocky9
+  "2.3-ubuntu22" ) disk_size_gb="48" ;; # 50G   45G  5.6G  89% / # rapids-pre-init-2-3-ubuntu22
 esac
 
 #disk_size_gb="50"


### PR DESCRIPTION
Following changes are done in this;

1. Running `./install_optional_components.sh` in its own session to avoid any conflicts in loaded variables.
2. Correcting the mapping of user-visible optional-component name to component names used inside image.
3. Setting DATAPROC_IMAGE_TYPE and DATAPROC_IMAGE_VERSION used inside some of the scripts.