### PR TITLE
Delay application of cluster configuration

### DIFF
--- a/examples/secure-boot/install_gpu_driver.sh
+++ b/examples/secure-boot/install_gpu_driver.sh
@@ -11,43 +11,60 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 #
 # This script installs NVIDIA GPU drivers and collects GPU utilization metrics.
 
-set -euxo pipefail
+set -xeuo pipefail
 
-function os_id()       ( set +x ; grep '^ID=' /etc/os-release | cut -d= -f2 | xargs ; )
-function os_version()  ( set +x ;  grep '^VERSION_ID=' /etc/os-release | cut -d= -f2 | xargs ; )
-function os_codename() ( set +x ;  grep '^VERSION_CODENAME=' /etc/os-release | cut -d= -f2 | xargs ; )
-function is_rocky()    ( set +x ;  [[ "$(os_id)" == 'rocky' ]] ; )
-function is_rocky8()   ( set +x ;  is_rocky && [[ "$(os_version)" == '8'* ]] ; )
-function is_rocky9()   ( set +x ;  is_rocky && [[ "$(os_version)" == '9'* ]] ; )
-function is_ubuntu()   ( set +x ;  [[ "$(os_id)" == 'ubuntu' ]] ; )
-function is_ubuntu18() ( set +x ;  is_ubuntu && [[ "$(os_version)" == '18.04'* ]] ; )
-function is_ubuntu20() ( set +x ;  is_ubuntu && [[ "$(os_version)" == '20.04'* ]] ; )
-function is_ubuntu22() ( set +x ;  is_ubuntu && [[ "$(os_version)" == '22.04'* ]] ; )
-function is_debian()   ( set +x ;  [[ "$(os_id)" == 'debian' ]] ; )
-function is_debian10() ( set +x ;  is_debian && [[ "$(os_version)" == '10'* ]] ; )
-function is_debian11() ( set +x ;  is_debian && [[ "$(os_version)" == '11'* ]] ; )
-function is_debian12() ( set +x ;  is_debian && [[ "$(os_version)" == '12'* ]] ; )
-function is_debuntu()  ( set +x ;  is_debian || is_ubuntu ; )
+function os_id()       { grep '^ID='               /etc/os-release | cut -d= -f2 | xargs ; }
+function os_version()  { grep '^VERSION_ID='       /etc/os-release | cut -d= -f2 | xargs ; }
+function os_codename() { grep '^VERSION_CODENAME=' /etc/os-release | cut -d= -f2 | xargs ; }
 
-function os_vercat()   ( set +x
+function version_ge(){ [[ "$1" = "$(echo -e "$1\n$2"|sort -V|tail -n1)" ]]; }
+function version_gt(){ [[ "$1" = "$2" ]]&& return 1 || version_ge "$1" "$2";}
+function version_le(){ [[ "$1" = "$(echo -e "$1\n$2"|sort -V|head -n1)" ]]; }
+function version_lt(){ [[ "$1" = "$2" ]]&& return 1 || version_le "$1" "$2";}
+
+readonly -A supported_os=(
+  ['debian']="10 11 12"
+  ['rocky']="8 9"
+  ['ubuntu']="18.04 20.04 22.04"
+)
+
+# dynamically define OS version test utility functions
+if [[ "$(os_id)" == "rocky" ]];
+  then _os_version=$(os_version | sed -e 's/[^0-9].*$//g')
+  else _os_version="$(os_version)"
+fi
+for os_id_val in 'rocky' 'ubuntu' 'debian' ; do
+  eval "function is_${os_id_val}() { [[ \"$(os_id)\" == '${os_id_val}' ]] ; }"
+
+  for osver in $(echo "${supported_os["${os_id_val}"]}") ; do
+    eval "function is_${os_id_val}${osver%%.*}() { is_${os_id_val} && [[ \"${_os_version}\" == \"${osver}\" ]] ; }"
+    eval "function ge_${os_id_val}${osver%%.*}() { is_${os_id_val} && version_ge \"${_os_version}\" \"${osver}\" ; }"
+    eval "function le_${os_id_val}${osver%%.*}() { is_${os_id_val} && version_le \"${_os_version}\" \"${osver}\" ; }"
+  done
+done
+
+function is_debuntu()  {  is_debian || is_ubuntu ; }
+
+function os_vercat()   {
   if   is_ubuntu ; then os_version | sed -e 's/[^0-9]//g'
   elif is_rocky  ; then os_version | sed -e 's/[^0-9].*$//g'
-                   else os_version ; fi ; )
+                   else os_version ; fi ; }
 
-function remove_old_backports {
-  if is_debian12 ; then return ; fi
+function repair_old_backports {
+  if ! is_debuntu ; then return ; fi
   # This script uses 'apt-get update' and is therefore potentially dependent on
   # backports repositories which have been archived.  In order to mitigate this
   # problem, we will use archive.debian.org for the oldoldstable repo
 
   # https://github.com/GoogleCloudDataproc/initialization-actions/issues/1157
   debdists="https://deb.debian.org/debian/dists"
-  oldoldstable=$(curl -s "${debdists}/oldoldstable/Release" | awk '/^Codename/ {print $2}');
-  oldstable=$(   curl -s "${debdists}/oldstable/Release"    | awk '/^Codename/ {print $2}');
-  stable=$(      curl -s "${debdists}/stable/Release"       | awk '/^Codename/ {print $2}');
+  oldoldstable=$(curl ${curl_retry_args} "${debdists}/oldoldstable/Release" | awk '/^Codename/ {print $2}');
+  oldstable=$(   curl ${curl_retry_args} "${debdists}/oldstable/Release"    | awk '/^Codename/ {print $2}');
+  stable=$(      curl ${curl_retry_args} "${debdists}/stable/Release"       | awk '/^Codename/ {print $2}');
 
   matched_files=( $(test -d /etc/apt && grep -rsil '\-backports' /etc/apt/sources.list*||:) )
 
@@ -57,14 +74,6 @@ function remove_old_backports {
                   {\$1 https://archive.debian.org/debian ${oldoldstable}-backports }g" "${filename}"
   done
 }
-
-# Return true if the first argument is equal to or less than the second argument
-function compare_versions_lte { [ "$1" = "$(echo -e "$1\n$2" | sort -V | head -n1)" ] ; }
-
-# Return true if the first argument is less than the second argument
-function compare_versions_lt() ( set +x
-  [ "$1" = "$2" ] && return 1 || compare_versions_lte $1 $2
-)
 
 function print_metadata_value() {
   local readonly tmpfile=$(mktemp)
@@ -87,8 +96,8 @@ function print_metadata_value_if_exists() {
   return ${return_code}
 }
 
-function get_metadata_value() (
-  set +x
+# replicates /usr/share/google/get_metadata_value
+function get_metadata_value() {
   local readonly varname=$1
   local -r MDS_PREFIX=http://metadata.google.internal/computeMetadata/v1
   # Print the instance metadata value.
@@ -99,18 +108,18 @@ function get_metadata_value() (
     print_metadata_value_if_exists ${MDS_PREFIX}/project/${varname}
     return_code=$?
   fi
-
   return ${return_code}
-)
+}
 
-function get_metadata_attribute() (
-  set +x
+function get_metadata_attribute() {
   local -r attribute_name="$1"
   local -r default_value="${2:-}"
+  set +e
   get_metadata_value "attributes/${attribute_name}" || echo -n "${default_value}"
-)
+  set -e
+}
 
-OS_NAME=$(lsb_release -is | tr '[:upper:]' '[:lower:]')
+OS_NAME="$(lsb_release -is | tr '[:upper:]' '[:lower:]')"
 distribution=$(. /etc/os-release;echo $ID$VERSION_ID)
 readonly OS_NAME
 
@@ -119,76 +128,186 @@ ROLE="$(get_metadata_attribute dataproc-role)"
 readonly ROLE
 
 # CUDA version and Driver version
+# https://docs.nvidia.com/deploy/cuda-compatibility/
 # https://docs.nvidia.com/deeplearning/frameworks/support-matrix/index.html
+# https://developer.nvidia.com/cuda-downloads
+
+# Minimum supported version for open kernel driver is 515.43.04
+# https://github.com/NVIDIA/open-gpu-kernel-modules/tags
 readonly -A DRIVER_FOR_CUDA=(
-          [11.8]="525.147.05" [12.1]="530.30.02"  [12.4]="550.54.14"
-          [12.5]="555.42.06"  [12.6]="560.28.03"
+    ["10.0"]="410.48" ["10.1"]="418.87.00" ["10.2"]="440.33.01"
+    ["11.1"]="455.45.01" ["11.2"]="460.91.03" ["11.3"]="465.31"
+    ["11.4"]="470.256.02" ["11.5"]="495.46" ["11.6"]="510.108.03"
+    ["11.7"]="515.65.01" ["11.8"]="525.147.05" ["12.0"]="525.147.05"
+    ["12.1"]="530.30.02" ["12.2"]="535.216.01" ["12.3"]="545.29.06"
+    ["12.4"]="550.135" ["12.5"]="550.142" ["12.6"]="550.142"
 )
+readonly -A DRIVER_SUBVER=(
+    ["410"]="410.104" ["415"]="415.27" ["418"]="418.113"
+    ["430"]="430.64" ["435"]="435.21" ["440"]="440.100"
+    ["450"]="450.119.03" ["455"]="455.45.01" ["460"]="460.91.03"
+    ["465"]="465.31" ["470"]="470.256.02" ["495"]="495.46"
+    ["510"]="510.108.03" ["515"]="515.48.07" ["520"]="525.147.05"
+    ["525"]="525.147.05" ["535"]="535.216.01" ["545"]="545.29.06"
+    ["550"]="550.142" ["555"]="555.58.02" ["560"]="560.35.03"
+    ["565"]="565.77"
+)
+# https://developer.nvidia.com/cudnn-downloads
 readonly -A CUDNN_FOR_CUDA=(
-          [11.8]="8.6.0.163"  [12.1]="8.9.0"      [12.4]="9.1.0.70"
-          [12.5]="9.2.1.18"
+    ["10.0"]="7.4.1" ["10.1"]="7.6.4" ["10.2"]="7.6.5"
+    ["11.0"]="8.0.4" ["11.1"]="8.0.5" ["11.2"]="8.1.1"
+    ["11.3"]="8.2.1" ["11.4"]="8.2.4.15" ["11.5"]="8.3.1.22"
+    ["11.6"]="8.4.0.27" ["11.7"]="8.9.7.29" ["11.8"]="9.5.1.17"
+    ["12.0"]="8.8.1.3" ["12.1"]="8.9.3.28" ["12.2"]="8.9.5"
+    ["12.3"]="9.0.0.306" ["12.4"]="9.1.0.70" ["12.5"]="9.2.1.18"
+    ["12.6"]="9.6.0.74"
 )
+# https://developer.nvidia.com/nccl/nccl-download
 readonly -A NCCL_FOR_CUDA=(
-          [11.8]="2.15.5"     [12.1]="2.17.1"     [12.4]="2.21.5"
-          [12.5]="2.22.3"
+    ["10.0"]="2.3.7" ["10.1"]= ["11.0"]="2.7.8" ["11.1"]="2.8.3"
+    ["11.2"]="2.8.4" ["11.3"]="2.9.9" ["11.4"]="2.11.4"
+    ["11.5"]="2.11.4" ["11.6"]="2.12.10" ["11.7"]="2.12.12"
+    ["11.8"]="2.21.5" ["12.0"]="2.16.5" ["12.1"]="2.18.3"
+    ["12.2"]="2.19.3" ["12.3"]="2.19.4" ["12.4"]="2.23.4"
+    ["12.5"]="2.22.3" ["12.6"]="2.23.4"
 )
 readonly -A CUDA_SUBVER=(
-          [11.8]="11.8.0"     [12.1]="12.1.0"     [12.4]="12.4.1"
-          [12.5]="12.5.1"
+    ["10.0"]="10.0.130" ["10.1"]="10.1.234" ["10.2"]="10.2.89"
+    ["11.0"]="11.0.3" ["11.1"]="11.1.1" ["11.2"]="11.2.2"
+    ["11.3"]="11.3.1" ["11.4"]="11.4.4" ["11.5"]="11.5.2"
+    ["11.6"]="11.6.2" ["11.7"]="11.7.1" ["11.8"]="11.8.0"
+    ["12.0"]="12.0.1" ["12.1"]="12.1.1" ["12.2"]="12.2.2"
+    ["12.3"]="12.3.2" ["12.4"]="12.4.1" ["12.5"]="12.5.1"
+    ["12.6"]="12.6.3"
 )
 
-RAPIDS_RUNTIME=$(get_metadata_attribute 'rapids-runtime' 'SPARK')
-readonly DEFAULT_CUDA_VERSION='12.4'
-CUDA_VERSION=$(get_metadata_attribute 'cuda-version' "${DEFAULT_CUDA_VERSION}")
-readonly CUDA_VERSION
-readonly CUDA_FULL_VERSION="${CUDA_SUBVER["${CUDA_VERSION}"]}"
+function set_cuda_version() {
+  case "${DATAPROC_IMAGE_VERSION}" in
+    "1.5" ) DEFAULT_CUDA_VERSION="11.6.2" ;;
+    "2.0" ) DEFAULT_CUDA_VERSION="12.1.1" ;; # Cuda 12.1.1 - Driver v530.30.02 is the latest version supported by Ubuntu 18)
+    "2.1" ) DEFAULT_CUDA_VERSION="12.4.1" ;;
+    "2.2" ) DEFAULT_CUDA_VERSION="12.6.3" ;;
+    "2.3" ) DEFAULT_CUDA_VERSION="12.6.3" ;;
+    *   )
+      echo "unrecognized Dataproc image version: ${DATAPROC_IMAGE_VERSION}"
+      exit 1
+      ;;
+  esac
+  local cuda_url
+  cuda_url=$(get_metadata_attribute 'cuda-url' '')
+  if [[ -n "${cuda_url}" ]] ; then
+    # if cuda-url metadata variable has been passed, extract default version from url
+    local CUDA_URL_VERSION
+    CUDA_URL_VERSION="$(echo "${cuda_url}" | perl -pe 's{^.*/cuda_(\d+\.\d+\.\d+)_\d+\.\d+\.\d+_linux.run$}{$1}')"
+    if [[ "${CUDA_URL_VERSION}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] ; then
+      DEFAULT_CUDA_VERSION="${CUDA_URL_VERSION}"
+    fi
+  fi
+  readonly DEFAULT_CUDA_VERSION
 
-function is_cuda12() ( set +x ; [[ "${CUDA_VERSION%%.*}" == "12" ]] ; )
-function is_cuda11() ( set +x ; [[ "${CUDA_VERSION%%.*}" == "11" ]] ; )
-readonly DEFAULT_DRIVER=${DRIVER_FOR_CUDA["${CUDA_VERSION}"]}
-DRIVER_VERSION=$(get_metadata_attribute 'gpu-driver-version' "${DEFAULT_DRIVER}")
-if is_debian11 || is_ubuntu22 || is_ubuntu20 ; then DRIVER_VERSION="560.28.03" ; fi
-if is_ubuntu20 && is_cuda11 ; then DRIVER_VERSION="535.183.06" ; fi
+  CUDA_VERSION=$(get_metadata_attribute 'cuda-version' "${DEFAULT_CUDA_VERSION}")
+  if test -n "$(echo "${CUDA_VERSION}" | perl -ne 'print if /\d+\.\d+\.\d+/')" ; then
+    CUDA_FULL_VERSION="${CUDA_VERSION}"
+    CUDA_VERSION="${CUDA_VERSION%.*}"
+  fi
+  readonly CUDA_VERSION
+  if ( ! test -v CUDA_FULL_VERSION ) ; then
+    CUDA_FULL_VERSION=${CUDA_SUBVER["${CUDA_VERSION}"]}
+  fi
+  readonly CUDA_FULL_VERSION
+}
 
-readonly DRIVER_VERSION
-readonly DRIVER=${DRIVER_VERSION%%.*}
+function is_cuda12() { [[ "${CUDA_VERSION%%.*}" == "12" ]] ; }
+function le_cuda12() { version_le "${CUDA_VERSION%%.*}" "12" ; }
+function ge_cuda12() { version_ge "${CUDA_VERSION%%.*}" "12" ; }
 
-# Parameters for NVIDIA-provided CUDNN library
-readonly DEFAULT_CUDNN_VERSION=${CUDNN_FOR_CUDA["${CUDA_VERSION}"]}
-CUDNN_VERSION=$(get_metadata_attribute 'cudnn-version' "${DEFAULT_CUDNN_VERSION}")
-function is_cudnn8() ( set +x ; [[ "${CUDNN_VERSION%%.*}" == "8" ]] ; )
-function is_cudnn9() ( set +x ; [[ "${CUDNN_VERSION%%.*}" == "9" ]] ; )
-if is_rocky \
-   && (compare_versions_lte "${CUDNN_VERSION}" "8.0.5.39") ; then
-  CUDNN_VERSION="8.0.5.39"
-elif (is_ubuntu20 || is_ubuntu22 || is_debian12) && is_cudnn8 ; then
-  # cuDNN v8 is not distribution for ubuntu20+, debian12
-  CUDNN_VERSION="9.1.0.70"
+function is_cuda11() { [[ "${CUDA_VERSION%%.*}" == "11" ]] ; }
+function le_cuda11() { version_le "${CUDA_VERSION%%.*}" "11" ; }
+function ge_cuda11() { version_ge "${CUDA_VERSION%%.*}" "11" ; }
 
-elif (is_ubuntu18 || is_debian10 || is_debian11) && is_cudnn9 ; then
-  # cuDNN v9 is not distributed for ubuntu18, debian10, debian11 ; fall back to 8
-  CUDNN_VERSION="8.8.0.121"
-fi
-readonly CUDNN_VERSION
+function set_driver_version() {
+  local gpu_driver_url
+  gpu_driver_url=$(get_metadata_attribute 'gpu-driver-url' '')
 
-readonly DEFAULT_NCCL_VERSION=${NCCL_FOR_CUDA["${CUDA_VERSION}"]}
-readonly NCCL_VERSION=$(get_metadata_attribute 'nccl-version' ${DEFAULT_NCCL_VERSION})
+  local cuda_url
+  cuda_url=$(get_metadata_attribute 'cuda-url' '')
 
-# Parameters for NVIDIA-provided Debian GPU driver
-readonly DEFAULT_USERSPACE_URL="https://download.nvidia.com/XFree86/Linux-x86_64/${DRIVER_VERSION}/NVIDIA-Linux-x86_64-${DRIVER_VERSION}.run"
+  local nv_xf86_x64_base="https://us.download.nvidia.com/XFree86/Linux-x86_64"
 
-readonly USERSPACE_URL=$(get_metadata_attribute 'gpu-driver-url' "${DEFAULT_USERSPACE_URL}")
+  local DEFAULT_DRIVER
+  # Take default from gpu-driver-url metadata value
+  if [[ -n "${gpu_driver_url}" ]] ; then
+    DRIVER_URL_DRIVER_VERSION="$(echo "${gpu_driver_url}" | perl -pe 's{^.*/NVIDIA-Linux-x86_64-(\d+\.\d+\.\d+).run$}{$1}')"
+    if [[ "${DRIVER_URL_DRIVER_VERSION}" =~ ^[0-9]+.*[0-9]$ ]] ; then DEFAULT_DRIVER="${DRIVER_URL_DRIVER_VERSION}" ; fi
+  # Take default from cuda-url metadata value as a backup
+  elif [[ -n "${cuda_url}" ]] ; then
+    local CUDA_URL_DRIVER_VERSION="$(echo "${cuda_url}" | perl -pe 's{^.*/cuda_\d+\.\d+\.\d+_(\d+\.\d+\.\d+)_linux.run$}{$1}')"
+    if [[ "${CUDA_URL_DRIVER_VERSION}" =~ ^[0-9]+.*[0-9]$ ]] ; then
+      major_driver_version="${CUDA_URL_DRIVER_VERSION%%.*}"
+      driver_max_maj_version=${DRIVER_SUBVER["${major_driver_version}"]}
+      if curl ${curl_retry_args} --head "${nv_xf86_x64_base}/${CUDA_URL_DRIVER_VERSION}/NVIDIA-Linux-x86_64-${CUDA_URL_DRIVER_VERSION}.run" | grep -E -q 'HTTP.*200' ; then
+        # use the version indicated by the cuda url as the default if it exists
+        DEFAULT_DRIVER="${CUDA_URL_DRIVER_VERSION}"
+      elif curl ${curl_retry_args} --head "${nv_xf86_x64_base}/${driver_max_maj_version}/NVIDIA-Linux-x86_64-${driver_max_maj_version}.run" | grep -E -q 'HTTP.*200' ; then
+        # use the maximum sub-version available for the major version indicated in cuda url as the default
+        DEFAULT_DRIVER="${driver_max_maj_version}"
+      fi
+    fi
+  fi
+
+  if ( ! test -v DEFAULT_DRIVER ) ; then
+    # If a default driver version has not been extracted, use the default for this version of CUDA
+    DEFAULT_DRIVER=${DRIVER_FOR_CUDA["${CUDA_VERSION}"]}
+  fi
+
+  DRIVER_VERSION=$(get_metadata_attribute 'gpu-driver-version' "${DEFAULT_DRIVER}")
+
+  readonly DRIVER_VERSION
+  readonly DRIVER="${DRIVER_VERSION%%.*}"
+
+  export DRIVER_VERSION DRIVER
+
+  gpu_driver_url="${nv_xf86_x64_base}/${DRIVER_VERSION}/NVIDIA-Linux-x86_64-${DRIVER_VERSION}.run"
+  if ! curl ${curl_retry_args} --head "${gpu_driver_url}" | grep -E -q 'HTTP.*200' ; then
+    echo "No NVIDIA driver exists for DRIVER_VERSION=${DRIVER_VERSION}"
+    exit 1
+  fi
+}
+
+function set_cudnn_version() {
+  readonly MIN_ROCKY8_CUDNN8_VERSION="8.0.5.39"
+  readonly DEFAULT_CUDNN8_VERSION="8.3.1.22"
+  readonly DEFAULT_CUDNN9_VERSION="9.1.0.70"
+
+  # Parameters for NVIDIA-provided cuDNN library
+  readonly DEFAULT_CUDNN_VERSION=${CUDNN_FOR_CUDA["${CUDA_VERSION}"]}
+  CUDNN_VERSION=$(get_metadata_attribute 'cudnn-version' "${DEFAULT_CUDNN_VERSION}")
+  # The minimum cuDNN version supported by rocky is ${MIN_ROCKY8_CUDNN8_VERSION}
+  if ( is_rocky  && version_lt "${CUDNN_VERSION}" "${MIN_ROCKY8_CUDNN8_VERSION}" ) ; then
+    CUDNN_VERSION="${MIN_ROCKY8_CUDNN8_VERSION}"
+  elif (ge_ubuntu20 || ge_debian12) && is_cudnn8 ; then
+    # cuDNN v8 is not distribution for ubuntu20+, debian12
+    CUDNN_VERSION="${DEFAULT_CUDNN9_VERSION}"
+  elif (le_ubuntu18 || le_debian11) && is_cudnn9 ; then
+    # cuDNN v9 is not distributed for ubuntu18, debian10, debian11 ; fall back to 8
+    CUDNN_VERSION="8.8.0.121"
+  fi
+  readonly CUDNN_VERSION
+}
+
+function is_cudnn8() { [[ "${CUDNN_VERSION%%.*}" == "8" ]] ; }
+function is_cudnn9() { [[ "${CUDNN_VERSION%%.*}" == "9" ]] ; }
 
 # Short name for urls
 if is_ubuntu22  ; then
-    # at the time of writing 20240721 there is no ubuntu2204 in the index of repos at
+    # at the time of writing 20241125 there is no ubuntu2204 in the index of repos at
     # https://developer.download.nvidia.com/compute/machine-learning/repos/
     # use packages from previous release until such time as nvidia
     # release ubuntu2204 builds
 
     nccl_shortname="ubuntu2004"
     shortname="$(os_id)$(os_vercat)"
-elif is_rocky9 ; then
+elif ge_rocky9 ; then
     # use packages from previous release until such time as nvidia
     # release rhel9 builds
 
@@ -202,52 +321,139 @@ else
     nccl_shortname="${shortname}"
 fi
 
-# Parameters for NVIDIA-provided package repositories
-readonly NVIDIA_BASE_DL_URL='https://developer.download.nvidia.com/compute'
-readonly NVIDIA_REPO_URL="${NVIDIA_BASE_DL_URL}/cuda/repos/${shortname}/x86_64"
+function set_nv_urls() {
+  # Parameters for NVIDIA-provided package repositories
+  readonly NVIDIA_BASE_DL_URL='https://developer.download.nvidia.com/compute'
+  readonly NVIDIA_REPO_URL="${NVIDIA_BASE_DL_URL}/cuda/repos/${shortname}/x86_64"
 
-# Parameters for NVIDIA-provided NCCL library
-readonly DEFAULT_NCCL_REPO_URL="${NVIDIA_BASE_DL_URL}/machine-learning/repos/${nccl_shortname}/x86_64/nvidia-machine-learning-repo-${nccl_shortname}_1.0.0-1_amd64.deb"
-NCCL_REPO_URL=$(get_metadata_attribute 'nccl-repo-url' "${DEFAULT_NCCL_REPO_URL}")
-readonly NCCL_REPO_URL
-readonly NCCL_REPO_KEY="${NVIDIA_BASE_DL_URL}/machine-learning/repos/${nccl_shortname}/x86_64/7fa2af80.pub" # 3bf863cc.pub
+  # Parameter for NVIDIA-provided Rocky Linux GPU driver
+  readonly NVIDIA_ROCKY_REPO_URL="${NVIDIA_REPO_URL}/cuda-${shortname}.repo"
+}
 
-readonly -A DEFAULT_NVIDIA_CUDA_URLS=(
-  [11.8]="${NVIDIA_BASE_DL_URL}/cuda/11.8.0/local_installers/cuda_11.8.0_520.61.05_linux.run"
-  [12.1]="${NVIDIA_BASE_DL_URL}/cuda/12.1.0/local_installers/cuda_12.1.0_530.30.02_linux.run"
-  [12.4]="${NVIDIA_BASE_DL_URL}/cuda/12.4.0/local_installers/cuda_12.4.0_550.54.14_linux.run"
-)
-readonly DEFAULT_NVIDIA_CUDA_URL=${DEFAULT_NVIDIA_CUDA_URLS["${CUDA_VERSION}"]}
-NVIDIA_CUDA_URL=$(get_metadata_attribute 'cuda-url' "${DEFAULT_NVIDIA_CUDA_URL}")
-readonly NVIDIA_CUDA_URL
+function set_cuda_runfile_url() {
+  local MAX_DRIVER_VERSION
+  local MAX_CUDA_VERSION
 
-# Parameter for NVIDIA-provided Rocky Linux GPU driver
-readonly NVIDIA_ROCKY_REPO_URL="${NVIDIA_REPO_URL}/cuda-${shortname}.repo"
+  MIN_OPEN_DRIVER_VER="515.43.04"
+  local MIN_DRIVER_VERSION="${MIN_OPEN_DRIVER_VER}"
+  local MIN_CUDA_VERSION="11.7.1" # matches MIN_OPEN_DRIVER_VER
 
+  if is_cuda12 ; then
+    if is_debian12 ; then
+      MIN_DRIVER_VERSION="545.23.06"
+      MIN_CUDA_VERSION="12.3.0"
+    elif is_debian10 ; then
+      MAX_DRIVER_VERSION="555.42.02"
+      MAX_CUDA_VERSION="12.5.0"
+    elif is_ubuntu18 ; then
+      MAX_DRIVER_VERSION="530.30.02"
+      MAX_CUDA_VERSION="12.1.1"
+    fi
+  elif version_ge "${CUDA_VERSION}" "${MIN_CUDA_VERSION}" ; then
+    if le_debian10 ; then
+      # cuda 11 is not supported for <= debian10
+      MAX_CUDA_VERSION="0"
+      MAX_DRIVER_VERSION="0"
+    fi
+  else
+    echo "Minimum CUDA version supported is ${MIN_CUDA_VERSION}.  Specified: ${CUDA_VERSION}"
+  fi
+
+  if version_lt "${CUDA_VERSION}" "${MIN_CUDA_VERSION}" ; then
+    echo "Minimum CUDA version for ${shortname} is ${MIN_CUDA_VERSION}.  Specified: ${CUDA_VERSION}"
+  elif ( test -v MAX_CUDA_VERSION && version_gt "${CUDA_VERSION}" "${MAX_CUDA_VERSION}" ) ; then
+    echo "Maximum CUDA version for ${shortname} is ${MAX_CUDA_VERSION}.  Specified: ${CUDA_VERSION}"
+  fi
+  if version_lt "${DRIVER_VERSION}" "${MIN_DRIVER_VERSION}" ; then
+    echo "Minimum kernel driver version for ${shortname} is ${MIN_DRIVER_VERSION}.  Specified: ${DRIVER_VERSION}"
+  elif ( test -v MAX_DRIVER_VERSION && version_gt "${DRIVER_VERSION}" "${MAX_DRIVER_VERSION}" ) ; then
+    echo "Maximum kernel driver version for ${shortname} is ${MAX_DRIVER_VERSION}.  Specified: ${DRIVER_VERSION}"
+  fi
+
+  # driver version named in cuda runfile filename
+  # (these may not be actual driver versions - see https://us.download.nvidia.com/XFree86/Linux-x86_64/)
+  readonly -A drv_for_cuda=(
+      ["10.0.130"]="410.48"
+      ["10.1.234"]="418.87.00"
+      ["10.2.89"]="440.33.01"
+      ["11.0.3"]="450.51.06"
+      ["11.1.1"]="455.32.00"
+      ["11.2.2"]="460.32.03"
+      ["11.3.1"]="465.19.01"
+      ["11.4.4"]="470.82.01"
+      ["11.5.2"]="495.29.05"
+      ["11.6.2"]="510.47.03"
+      ["11.7.0"]="515.43.04" ["11.7.1"]="515.65.01"
+      ["11.8.0"]="520.61.05"
+      ["12.0.0"]="525.60.13" ["12.0.1"]="525.85.12"
+      ["12.1.0"]="530.30.02" ["12.1.1"]="530.30.02"
+      ["12.2.0"]="535.54.03" ["12.2.1"]="535.86.10" ["12.2.2"]="535.104.05"
+      ["12.3.0"]="545.23.06" ["12.3.1"]="545.23.08" ["12.3.2"]="545.23.08"
+      ["12.4.0"]="550.54.14" ["12.4.1"]="550.54.15" # 550.54.15 is not a driver indexed at https://us.download.nvidia.com/XFree86/Linux-x86_64/
+      ["12.5.0"]="555.42.02" ["12.5.1"]="555.42.06" # 555.42.02 is indexed, 555.42.06 is not
+      ["12.6.0"]="560.28.03" ["12.6.1"]="560.35.03" ["12.6.2"]="560.35.03" ["12.6.3"]="560.35.05"
+  )
+
+  # Verify that the file with the indicated combination exists
+  local drv_ver=${drv_for_cuda["${CUDA_FULL_VERSION}"]}
+  CUDA_RUNFILE="cuda_${CUDA_FULL_VERSION}_${drv_ver}_linux.run"
+  local CUDA_RELEASE_BASE_URL="${NVIDIA_BASE_DL_URL}/cuda/${CUDA_FULL_VERSION}"
+  local DEFAULT_NVIDIA_CUDA_URL="${CUDA_RELEASE_BASE_URL}/local_installers/${CUDA_RUNFILE}"
+
+  NVIDIA_CUDA_URL=$(get_metadata_attribute 'cuda-url' "${DEFAULT_NVIDIA_CUDA_URL}")
+
+  if ! curl ${curl_retry_args} --head "${NVIDIA_CUDA_URL}" | grep -E -q 'HTTP.*200' ; then
+    echo "No CUDA distribution exists for this combination of DRIVER_VERSION=${drv_ver}, CUDA_VERSION=${CUDA_FULL_VERSION}"
+    if [[ "${DEFAULT_NVIDIA_CUDA_URL}" != "${NVIDIA_CUDA_URL}" ]]; then
+      echo "consider [${DEFAULT_NVIDIA_CUDA_URL}] instead"
+    fi
+    exit 1
+  fi
+
+  readonly NVIDIA_CUDA_URL
+
+  CUDA_RUNFILE="$(echo ${NVIDIA_CUDA_URL} | perl -pe 's{^.+/}{}')"
+  readonly CUDA_RUNFILE
+
+  if ( version_lt "${CUDA_FULL_VERSION}" "12.3.0" && ge_debian12 ) ; then
+    echo "CUDA 12.3.0 is the minimum CUDA 12 version supported on Debian 12"
+  elif ( version_gt "${CUDA_VERSION}" "12.1.1" && is_ubuntu18 ) ; then
+    echo "CUDA 12.1.1 is the maximum CUDA version supported on ubuntu18.  Requested version: ${CUDA_VERSION}"
+  elif ( version_lt "${CUDA_VERSION%%.*}" "12" && ge_debian12 ) ; then
+    echo "CUDA 11 not supported on Debian 12. Requested version: ${CUDA_VERSION}"
+  elif ( version_lt "${CUDA_VERSION}" "11.8" && is_rocky9 ) ; then
+    echo "CUDA 11.8.0 is the minimum version for Rocky 9. Requested version: ${CUDA_VERSION}"
+  fi
+}
+
+function set_cudnn_tarball_url() {
 CUDNN_TARBALL="cudnn-${CUDA_VERSION}-linux-x64-v${CUDNN_VERSION}.tgz"
 CUDNN_TARBALL_URL="${NVIDIA_BASE_DL_URL}/redist/cudnn/v${CUDNN_VERSION%.*}/${CUDNN_TARBALL}"
-if ( compare_versions_lte "8.3.1.22" "${CUDNN_VERSION}" ); then
+if ( version_ge "${CUDNN_VERSION}" "8.3.1.22" ); then
+  # When version is greater than or equal to 8.3.1.22 but less than 8.4.1.50 use this format
   CUDNN_TARBALL="cudnn-linux-x86_64-${CUDNN_VERSION}_cuda${CUDA_VERSION%.*}-archive.tar.xz"
-  if ( compare_versions_lte "${CUDNN_VERSION}" "8.4.1.50" ); then
+  if ( version_le "${CUDNN_VERSION}" "8.4.1.50" ); then
+    # When cuDNN version is greater than or equal to 8.4.1.50 use this format
     CUDNN_TARBALL="cudnn-linux-x86_64-${CUDNN_VERSION}_cuda${CUDA_VERSION}-archive.tar.xz"
   fi
+  # Use legacy url format with one of the tarball name formats depending on version as above
   CUDNN_TARBALL_URL="${NVIDIA_BASE_DL_URL}/redist/cudnn/v${CUDNN_VERSION%.*}/local_installers/${CUDA_VERSION}/${CUDNN_TARBALL}"
 fi
-if ( compare_versions_lte "12.0" "${CUDA_VERSION}" ); then
-  # When cuda version is greater than 12.0
-  CUDNN_TARBALL_URL="${NVIDIA_BASE_DL_URL}/cudnn/redist/cudnn/linux-x86_64/cudnn-linux-x86_64-9.2.0.82_cuda12-archive.tar.xz"
+if ( version_ge "${CUDA_VERSION}" "12.0" ); then
+  # Use modern url format When cuda version is greater than or equal to 12.0
+  CUDNN_TARBALL="cudnn-linux-x86_64-${CUDNN_VERSION}_cuda${CUDA_VERSION%%.*}-archive.tar.xz"
+  CUDNN_TARBALL_URL="${NVIDIA_BASE_DL_URL}/cudnn/redist/cudnn/linux-x86_64/${CUDNN_TARBALL}"
 fi
 readonly CUDNN_TARBALL
 readonly CUDNN_TARBALL_URL
+}
 
 # Whether to install NVIDIA-provided or OS-provided GPU driver
 GPU_DRIVER_PROVIDER=$(get_metadata_attribute 'gpu-driver-provider' 'NVIDIA')
 readonly GPU_DRIVER_PROVIDER
 
-# Stackdriver GPU agent parameters
-readonly GPU_AGENT_REPO_URL='https://raw.githubusercontent.com/GoogleCloudPlatform/ml-on-gcp/master/dlvm/gcp-gpu-utilization-metrics'
 # Whether to install GPU monitoring agent that sends GPU metrics to Stackdriver
-INSTALL_GPU_AGENT=$(get_metadata_attribute 'install-gpu-agent' 'false')
+INSTALL_GPU_AGENT=$(get_metadata_attribute 'install-gpu-agent' 'true')
 readonly INSTALL_GPU_AGENT
 
 # Dataproc configurations
@@ -259,96 +465,96 @@ NVIDIA_SMI_PATH='/usr/bin'
 MIG_MAJOR_CAPS=0
 IS_MIG_ENABLED=0
 
+IS_CUSTOM_IMAGE_BUILD="false" # Default
+
 function execute_with_retries() (
-  set +x
   local -r cmd="$*"
 
   if [[ "$cmd" =~ "^apt-get install" ]] ; then
-    cmd="apt-get -y clean && $cmd"
+    apt-get -y clean
+    apt-get -o DPkg::Lock::Timeout=60 -y autoremove
   fi
   for ((i = 0; i < 3; i++)); do
-    if eval "$cmd" ; then return 0 ; fi
+    time eval "$cmd" > "${install_log}" 2>&1 && retval=$? || { retval=$? ; cat "${install_log}" ; }
+    if [[ $retval == 0 ]] ; then return 0 ; fi
     sleep 5
   done
   return 1
 )
 
-CUDA_KEYRING_PKG_INSTALLED="0"
 function install_cuda_keyring_pkg() {
-  if [[ "${CUDA_KEYRING_PKG_INSTALLED}" == "1" ]]; then return ; fi
+  is_complete cuda-keyring-installed && return
   local kr_ver=1.1
-  curl -fsSL --retry-connrefused --retry 10 --retry-max-time 30 \
+  curl ${curl_retry_args} \
     "${NVIDIA_REPO_URL}/cuda-keyring_${kr_ver}-1_all.deb" \
-    -o "${download_dir}/cuda-keyring.deb"
-  dpkg -i "${download_dir}/cuda-keyring.deb"
-  rm -f "${download_dir}/cuda-keyring.deb"
-  CUDA_KEYRING_PKG_INSTALLED="1"
+    -o "${tmpdir}/cuda-keyring.deb"
+  dpkg -i "${tmpdir}/cuda-keyring.deb"
+  rm -f "${tmpdir}/cuda-keyring.deb"
+  mark_complete cuda-keyring-installed
 }
 
 function uninstall_cuda_keyring_pkg() {
   apt-get purge -yq cuda-keyring
-  CUDA_KEYRING_PKG_INSTALLED="0"
+  mark_incomplete cuda-keyring-installed
 }
 
-CUDA_LOCAL_REPO_INSTALLED="0"
 function install_local_cuda_repo() {
-  if [[ "${CUDA_LOCAL_REPO_INSTALLED}" == "1" ]]; then return ; fi
-  CUDA_LOCAL_REPO_INSTALLED="1"
+  is_complete install-local-cuda-repo && return
+
   pkgname="cuda-repo-${shortname}-${CUDA_VERSION//./-}-local"
   CUDA_LOCAL_REPO_PKG_NAME="${pkgname}"
   readonly LOCAL_INSTALLER_DEB="${pkgname}_${CUDA_FULL_VERSION}-${DRIVER_VERSION}-1_amd64.deb"
   readonly LOCAL_DEB_URL="${NVIDIA_BASE_DL_URL}/cuda/${CUDA_FULL_VERSION}/local_installers/${LOCAL_INSTALLER_DEB}"
   readonly DIST_KEYRING_DIR="/var/${pkgname}"
 
-  curl -fsSL --retry-connrefused --retry 3 --retry-max-time 5 \
-    "${LOCAL_DEB_URL}" -o "${download_dir}/${LOCAL_INSTALLER_DEB}"
+  curl ${curl_retry_args} \
+    "${LOCAL_DEB_URL}" -o "${tmpdir}/${LOCAL_INSTALLER_DEB}"
 
-  dpkg -i "${download_dir}/${LOCAL_INSTALLER_DEB}"
-  rm "${download_dir}/${LOCAL_INSTALLER_DEB}"
+  dpkg -i "${tmpdir}/${LOCAL_INSTALLER_DEB}"
+  rm "${tmpdir}/${LOCAL_INSTALLER_DEB}"
   cp ${DIST_KEYRING_DIR}/cuda-*-keyring.gpg /usr/share/keyrings/
 
   if is_ubuntu ; then
-    curl -fsSL --retry-connrefused --retry 10 --retry-max-time 30 \
+    curl ${curl_retry_args} \
       "${NVIDIA_REPO_URL}/cuda-${shortname}.pin" \
       -o /etc/apt/preferences.d/cuda-repository-pin-600
   fi
+
+  mark_complete install-local-cuda-repo
 }
 function uninstall_local_cuda_repo(){
   apt-get purge -yq "${CUDA_LOCAL_REPO_PKG_NAME}"
-  CUDA_LOCAL_REPO_INSTALLED="0"
+  mark_incomplete install-local-cuda-repo
 }
 
-CUDNN_LOCAL_REPO_INSTALLED="0"
-CUDNN_PKG_NAME=""
 function install_local_cudnn_repo() {
-  if [[ "${CUDNN_LOCAL_REPO_INSTALLED}" == "1" ]]; then return ; fi
-  pkgname="cudnn-local-repo-${shortname}-${CUDNN}"
+  is_complete install-local-cudnn-repo && return
+  pkgname="cudnn-local-repo-${shortname}-${CUDNN_VERSION%.*}"
   CUDNN_PKG_NAME="${pkgname}"
   local_deb_fn="${pkgname}_1.0-1_amd64.deb"
-  local_deb_url="${NVIDIA_BASE_DL_URL}/cudnn/${CUDNN}/local_installers/${local_deb_fn}"
+  local_deb_url="${NVIDIA_BASE_DL_URL}/cudnn/${CUDNN_VERSION%.*}/local_installers/${local_deb_fn}"
 
   # ${NVIDIA_BASE_DL_URL}/redist/cudnn/v8.6.0/local_installers/11.8/cudnn-linux-x86_64-8.6.0.163_cuda11-archive.tar.xz
-  curl -fsSL --retry-connrefused --retry 3 --retry-max-time 5 \
-    "${local_deb_url}" -o "${download_dir}/local-installer.deb"
+  curl ${curl_retry_args} \
+    "${local_deb_url}" -o "${tmpdir}/local-installer.deb"
 
-  dpkg -i "${download_dir}/local-installer.deb"
+  dpkg -i "${tmpdir}/local-installer.deb"
 
-  rm -f "${download_dir}/local-installer.deb"
+  rm -f "${tmpdir}/local-installer.deb"
 
-  cp /var/cudnn-local-repo-*-${CUDNN}*/cudnn-local-*-keyring.gpg /usr/share/keyrings
+  cp /var/cudnn-local-repo-*-${CUDNN_VERSION%.*}*/cudnn-local-*-keyring.gpg /usr/share/keyrings
 
-  CUDNN_LOCAL_REPO_INSTALLED="1"
+  mark_complete install-local-cudnn-repo
 }
 
 function uninstall_local_cudnn_repo() {
   apt-get purge -yq "${CUDNN_PKG_NAME}"
-  CUDNN_LOCAL_REPO_INSTALLED="0"
+  mark_incomplete install-local-cudnn-repo
 }
 
-CUDNN8_LOCAL_REPO_INSTALLED="0"
-CUDNN8_PKG_NAME=""
 function install_local_cudnn8_repo() {
-  if [[ "${CUDNN8_LOCAL_REPO_INSTALLED}" == "1" ]]; then return ; fi
+  is_complete install-local-cudnn8-repo && return
+
   if   is_ubuntu ; then cudnn8_shortname="ubuntu2004"
   elif is_debian ; then cudnn8_shortname="debian11"
   else return 0 ; fi
@@ -361,65 +567,165 @@ function install_local_cudnn8_repo() {
   CUDNN8_PKG_NAME="${pkgname}"
 
   deb_fn="${pkgname}_1.0-1_amd64.deb"
-  local_deb_fn="${download_dir}/${deb_fn}"
-  local_deb_url="${NVIDIA_BASE_DL_URL}/redist/cudnn/v${CUDNN}/local_installers/${CUDNN8_CUDA_VER}/${deb_fn}"
-  curl -fsSL --retry-connrefused --retry 3 --retry-max-time 5 \
-      "${local_deb_url}" -o "${local_deb_fn}"
+  local_deb_fn="${tmpdir}/${deb_fn}"
+  local_deb_url="${NVIDIA_BASE_DL_URL}/redist/cudnn/v${CUDNN_VERSION%.*}/local_installers/${CUDNN8_CUDA_VER}/${deb_fn}"
+
+  # cache the cudnn package
+  cache_fetched_package "${local_deb_url}" \
+                        "${pkg_bucket}/nvidia/cudnn/${CUDNN8_CUDA_VER}/${deb_fn}" \
+                        "${local_deb_fn}"
+
+  local cudnn_path="$(dpkg -c ${local_deb_fn} | perl -ne 'if(m{(/var/cudnn-local-repo-.*)/\s*$}){print $1}')"
+  # If we are using a ram disk, mount another where we will unpack the cudnn local installer
+  if [[ "${tmpdir}" == "/mnt/shm" ]] && ! grep -q '/var/cudnn-local-repo' /proc/mounts ; then
+    mkdir -p "${cudnn_path}"
+    mount -t tmpfs tmpfs "${cudnn_path}"
+  fi
 
   dpkg -i "${local_deb_fn}"
 
   rm -f "${local_deb_fn}"
 
-  cp /var/cudnn-local-repo-*-${CUDNN}*/cudnn-local-*-keyring.gpg /usr/share/keyrings
-  CUDNN8_LOCAL_REPO_INSTALLED="1"
+  cp "${cudnn_path}"/cudnn-local-*-keyring.gpg /usr/share/keyrings
+  mark_complete install-local-cudnn8-repo
 }
 
 function uninstall_local_cudnn8_repo() {
   apt-get purge -yq "${CUDNN8_PKG_NAME}"
-  CUDNN8_LOCAL_REPO_INSTALLED="0"
+  mark_incomplete install-local-cudnn8-repo
 }
 
 function install_nvidia_nccl() {
-  local -r nccl_version="${NCCL_VERSION}-1+cuda${CUDA_VERSION}"
+  readonly DEFAULT_NCCL_VERSION=${NCCL_FOR_CUDA["${CUDA_VERSION}"]}
+  readonly NCCL_VERSION=$(get_metadata_attribute 'nccl-version' ${DEFAULT_NCCL_VERSION})
 
-  if is_rocky ; then
-    time execute_with_retries \
-      dnf -y -q install \
-        "libnccl-${nccl_version}" "libnccl-devel-${nccl_version}" "libnccl-static-${nccl_version}" \
-        > "${install_log}" 2>&1 || { cat "${install_log}" && exit -4 ; }
-    sync
-  elif is_ubuntu ; then
-    install_cuda_keyring_pkg
+  is_complete nccl && return
 
-    apt-get update -qq
-
-    if is_ubuntu18 ; then
-      time execute_with_retries \
-        apt-get install -q -y \
-          libnccl2 libnccl-dev \
-          > "${install_log}" 2>&1 || { cat "${install_log}" && exit -4 ; }
-      sync
-    else
-      time execute_with_retries \
-        apt-get install -q -y \
-          "libnccl2=${nccl_version}" "libnccl-dev=${nccl_version}" \
-          > "${install_log}" 2>&1 || { cat "${install_log}" && exit -4 ; }
-      sync
-    fi
-  else
-    echo "Unsupported OS: '${OS_NAME}'"
-    # NB: this tarball is 10GB in size, but can be used to install NCCL on non-ubuntu systems
-    # wget https://developer.download.nvidia.com/hpc-sdk/24.7/nvhpc_2024_247_Linux_x86_64_cuda_multi.tar.gz
-    # tar xpzf nvhpc_2024_247_Linux_x86_64_cuda_multi.tar.gz
-    # nvhpc_2024_247_Linux_x86_64_cuda_multi/install
+  if is_cuda11 && is_debian12 ; then
+    echo "NCCL cannot be compiled for CUDA 11 on ${_shortname}"
     return
   fi
+
+  local -r nccl_version="${NCCL_VERSION}-1+cuda${CUDA_VERSION}"
+
+  mkdir -p "${workdir}"
+  pushd "${workdir}"
+
+  test -d "${workdir}/nccl" || {
+    local tarball_fn="v${NCCL_VERSION}-1.tar.gz"
+    curl ${curl_retry_args} \
+      "https://github.com/NVIDIA/nccl/archive/refs/tags/${tarball_fn}" \
+      | tar xz
+    mv "nccl-${NCCL_VERSION}-1" nccl
+  }
+
+  local build_path
+  if is_debuntu ; then build_path="nccl/build/pkg/deb" ; else
+                       build_path="nccl/build/pkg/rpm/x86_64" ; fi
+
+  test -d "${workdir}/nccl/build" || {
+    local build_tarball="nccl-build_${_shortname}_${nccl_version}.tar.gz"
+    local local_tarball="${workdir}/${build_tarball}"
+    local gcs_tarball="${pkg_bucket}/nvidia/nccl/${_shortname}/${build_tarball}"
+
+    if [[ "$(hostname -s)" =~ ^test-gpu && "$(nproc)" < 32 ]] ; then
+      # when running with fewer than 32 cores, yield to in-progress build
+      sleep $(( ( RANDOM % 11 ) + 10 ))
+      local output="$(${gsutil_stat_cmd} "${gcs_tarball}.building"|grep '.reation.time')"
+      if [[ "$?" == "0" ]] ; then
+        local build_start_time build_start_epoch timeout_epoch
+        build_start_time="$(echo ${output} | awk -F': +' '{print $2}')"
+        build_start_epoch="$(date -u -d "${build_start_time}" +%s)"
+        timeout_epoch=$((build_start_epoch + 2700)) # 45 minutes
+        while ${gsutil_stat_cmd} "${gcs_tarball}.building" ; do
+          local now_epoch="$(date -u +%s)"
+          if (( now_epoch > timeout_epoch )) ; then
+            # detect unexpected build failure after 45m
+            ${gsutil_cmd} rm "${gcs_tarball}.building"
+            break
+          fi
+          sleep 5m
+        done
+      fi
+    fi
+
+    if ${gsutil_stat_cmd} "${gcs_tarball}" ; then
+      # cache hit - unpack from cache
+      echo "cache hit"
+      ${gsutil_cmd} cat "${gcs_tarball}" | tar xvz
+    else
+      # build and cache
+      touch "${local_tarball}.building"
+      ${gsutil_cmd} cp "${local_tarball}.building" "${gcs_tarball}.building"
+      building_file="${gcs_tarball}.building"
+      pushd nccl
+      # https://github.com/NVIDIA/nccl?tab=readme-ov-file#install
+      install_build_dependencies
+
+      # https://github.com/NVIDIA/nccl/blob/master/README.md
+      # https://arnon.dk/matching-sm-architectures-arch-and-gencode-for-various-nvidia-cards/
+      # Fermi:     SM_20,             compute_30
+      # Kepler:    SM_30,SM_35,SM_37, compute_30,compute_35,compute_37
+      # Maxwell:   SM_50,SM_52,SM_53, compute_50,compute_52,compute_53
+      # Pascal:    SM_60,SM_61,SM_62, compute_60,compute_61,compute_62
+
+      # The following architectures are suppored by open kernel driver
+      # Volta:     SM_70,SM_72,       compute_70,compute_72
+      # Ampere:    SM_80,SM_86,SM_87, compute_80,compute_86,compute_87
+
+      # The following architectures are supported by CUDA v11.8+
+      # Ada:       SM_89,             compute_89
+      # Hopper:    SM_90,SM_90a       compute_90,compute_90a
+      # Blackwell: SM_100,            compute_100
+                      NVCC_GENCODE="-gencode=arch=compute_70,code=sm_70 -gencode=arch=compute_72,code=sm_72"
+      NVCC_GENCODE="${NVCC_GENCODE} -gencode=arch=compute_80,code=sm_80 -gencode=arch=compute_86,code=sm_86"
+      if version_gt "${CUDA_VERSION}" "11.6" ; then
+        NVCC_GENCODE="${NVCC_GENCODE} -gencode=arch=compute_87,code=sm_87" ; fi
+      if version_ge "${CUDA_VERSION}" "11.8" ; then
+        NVCC_GENCODE="${NVCC_GENCODE} -gencode=arch=compute_89,code=sm_89" ; fi
+      if version_ge "${CUDA_VERSION}" "12.0" ; then
+        NVCC_GENCODE="${NVCC_GENCODE} -gencode=arch=compute_90,code=sm_90 -gencode=arch=compute_90a,code=compute_90a" ; fi
+
+      if is_debuntu ; then
+        # These packages are required to build .deb packages from source
+        execute_with_retries \
+          apt-get install -y -qq build-essential devscripts debhelper fakeroot
+        export NVCC_GENCODE
+        execute_with_retries make -j$(nproc) pkg.debian.build
+      elif is_rocky ; then
+        # These packages are required to build .rpm packages from source
+        execute_with_retries \
+          dnf -y -q install rpm-build rpmdevtools
+        export NVCC_GENCODE
+        execute_with_retries make -j$(nproc) pkg.redhat.build
+      fi
+      tar czvf "${local_tarball}" "../${build_path}"
+      make clean
+      popd
+      tar xzvf "${local_tarball}"
+      ${gsutil_cmd} cp "${local_tarball}" "${gcs_tarball}"
+      if ${gsutil_stat_cmd} "${gcs_tarball}.building" ; then ${gsutil_cmd} rm "${gcs_tarball}.building" || true ; fi
+      building_file=""
+      rm "${local_tarball}"
+    fi
+  }
+
+  if is_debuntu ; then
+    dpkg -i "${build_path}/libnccl${NCCL_VERSION%%.*}_${nccl_version}_amd64.deb" "${build_path}/libnccl-dev_${nccl_version}_amd64.deb"
+  elif is_rocky ; then
+    rpm -ivh "${build_path}/libnccl-${nccl_version}.x86_64.rpm" "${build_path}/libnccl-devel-${nccl_version}.x86_64.rpm"
+  fi
+
+  popd
+  mark_complete nccl
 }
 
-function is_src_nvidia() ( set +x ; [[ "${GPU_DRIVER_PROVIDER}" == "NVIDIA" ]] ; )
-function is_src_os()     ( set +x ; [[ "${GPU_DRIVER_PROVIDER}" == "OS" ]] ; )
+function is_src_nvidia() { [[ "${GPU_DRIVER_PROVIDER}" == "NVIDIA" ]] ; }
+function is_src_os()     { [[ "${GPU_DRIVER_PROVIDER}" == "OS" ]] ; }
 
 function install_nvidia_cudnn() {
+  is_complete cudnn && return
+  if le_debian10 ; then return ; fi
   local major_version
   major_version="${CUDNN_VERSION%%.*}"
   local cudnn_pkg_version
@@ -427,61 +733,51 @@ function install_nvidia_cudnn() {
 
   if is_rocky ; then
     if is_cudnn8 ; then
-      time execute_with_retries dnf -y -q install \
+      execute_with_retries dnf -y -q install \
         "libcudnn${major_version}" \
-        "libcudnn${major_version}-devel" \
-        > "${install_log}" 2>&1 || { cat "${install_log}" && exit -4 ; }
+        "libcudnn${major_version}-devel"
       sync
     elif is_cudnn9 ; then
-      time execute_with_retries dnf -y -q install \
+      execute_with_retries dnf -y -q install \
         "libcudnn9-static-cuda-${CUDA_VERSION%%.*}" \
-        "libcudnn9-devel-cuda-${CUDA_VERSION%%.*}" \
-        > "${install_log}" 2>&1 || { cat "${install_log}" && exit -4 ; }
+        "libcudnn9-devel-cuda-${CUDA_VERSION%%.*}"
       sync
     else
       echo "Unsupported cudnn version: '${major_version}'"
     fi
   elif is_debuntu; then
-    if is_debian12 && is_src_os ; then
+    if ge_debian12 && is_src_os ; then
       apt-get -y install nvidia-cudnn
     else
-      local CUDNN="${CUDNN_VERSION%.*}"
       if is_cudnn8 ; then
-        install_local_cudnn8_repo
+        add_repo_cuda
 
         apt-get update -qq
+        # Ignore version requested and use the latest version in the package index
+        cudnn_pkg_version="$(apt-cache show libcudnn8 | awk "/^Ver.*cuda${CUDA_VERSION%%.*}.*/ {print \$2}" | sort -V | tail -1)"
 
-        time execute_with_retries \
+        execute_with_retries \
           apt-get -y install --no-install-recommends \
             "libcudnn8=${cudnn_pkg_version}" \
-            "libcudnn8-dev=${cudnn_pkg_version}" \
-            > "${install_log}" 2>&1 || { cat "${install_log}" && exit -4 ; }
-	sync
+            "libcudnn8-dev=${cudnn_pkg_version}"
+
+        sync
       elif is_cudnn9 ; then
-	install_cuda_keyring_pkg
+        install_cuda_keyring_pkg
 
         apt-get update -qq
 
-        time execute_with_retries \
+        execute_with_retries \
           apt-get -y install --no-install-recommends \
           "libcudnn9-cuda-${CUDA_VERSION%%.*}" \
           "libcudnn9-dev-cuda-${CUDA_VERSION%%.*}" \
-          "libcudnn9-static-cuda-${CUDA_VERSION%%.*}" \
-          > "${install_log}" 2>&1 || { cat "${install_log}" && exit -4 ; }
-	sync
+          "libcudnn9-static-cuda-${CUDA_VERSION%%.*}"
+
+        sync
       else
         echo "Unsupported cudnn version: [${CUDNN_VERSION}]"
       fi
     fi
-  elif is_ubuntu ; then
-    local -a packages
-    packages=(
-      "libcudnn${major_version}=${cudnn_pkg_version}"
-      "libcudnn${major_version}-dev=${cudnn_pkg_version}")
-    time execute_with_retries \
-      apt-get install -q -y --no-install-recommends "${packages[*]}" \
-      > "${install_log}" 2>&1 || { cat "${install_log}" && exit -4 ; }
-    sync
   else
     echo "Unsupported OS: '${OS_NAME}'"
     exit 1
@@ -490,13 +786,93 @@ function install_nvidia_cudnn() {
   ldconfig
 
   echo "NVIDIA cuDNN successfully installed for ${OS_NAME}."
+  mark_complete cudnn
 }
 
-CA_TMPDIR="$(mktemp -u -d -p /run/tmp -t ca_dir-XXXX)"
-PSN="$(get_metadata_attribute private_secret_name)"
-readonly PSN
+function install_pytorch() {
+  is_complete pytorch && return
+
+  local env
+  env=$(get_metadata_attribute 'gpu-conda-env' 'dpgce')
+
+  local conda_root_path
+  if version_lt "${DATAPROC_IMAGE_VERSION}" "2.3" ; then
+    conda_root_path="/opt/conda/miniconda3"
+  else
+    conda_root_path="/opt/conda"
+  fi
+  [[ -d ${conda_root_path} ]] || return
+  local envpath="${conda_root_path}/envs/${env}"
+  if [[ "${env}" == "base" ]]; then
+    echo "WARNING: installing to base environment known to cause solve issues" ; envpath="${conda_root_path}" ; fi
+  # Set numa node to 0 for all GPUs
+  for f in $(ls /sys/module/nvidia/drivers/pci:nvidia/*/numa_node) ; do echo 0 > ${f} ; done
+
+  local build_tarball="pytorch_${env}_${_shortname}_cuda${CUDA_VERSION}.tar.gz"
+  local local_tarball="${workdir}/${build_tarball}"
+  local gcs_tarball="${pkg_bucket}/conda/${_shortname}/${build_tarball}"
+
+  if [[ "$(hostname -s)" =~ ^test && "$(nproc)" < 32 ]] ; then
+    # when running with fewer than 32 cores, yield to in-progress build
+    sleep $(( ( RANDOM % 11 ) + 10 ))
+    local output="$(${gsutil_stat_cmd} "${gcs_tarball}.building"|grep '.reation.time')"
+    if [[ "$?" == "0" ]] ; then
+      local build_start_time build_start_epoch timeout_epoch
+      build_start_time="$(echo ${output} | awk -F': +' '{print $2}')"
+      build_start_epoch="$(date -u -d "${build_start_time}" +%s)"
+      timeout_epoch=$((build_start_epoch + 2700)) # 45 minutes
+      while ${gsutil_stat_cmd} "${gcs_tarball}.building" ; do
+        local now_epoch="$(date -u +%s)"
+        if (( now_epoch > timeout_epoch )) ; then
+          # detect unexpected build failure after 45m
+          ${gsutil_cmd} rm "${gcs_tarball}.building"
+          break
+        fi
+        sleep 5m
+      done
+    fi
+  fi
+
+  if ${gsutil_stat_cmd} "${gcs_tarball}" ; then
+    # cache hit - unpack from cache
+    echo "cache hit"
+    mkdir -p "${envpath}"
+    ${gsutil_cmd} cat "${gcs_tarball}" | tar -C "${envpath}" -xz
+  else
+    touch "${local_tarball}.building"
+    ${gsutil_cmd} cp "${local_tarball}.building" "${gcs_tarball}.building"
+    building_file="${gcs_tarball}.building"
+    local verb=create
+    if test -d "${envpath}" ; then verb=install ; fi
+    cudart_spec="cuda-cudart"
+    if le_cuda11 ; then cudart_spec="cudatoolkit" ; fi
+
+    # Install pytorch and company to this environment
+    "${conda_root_path}/bin/mamba" "${verb}" -n "${env}" \
+      -c conda-forge -c nvidia -c rapidsai \
+      numba pytorch tensorflow[and-cuda] rapids pyspark \
+      "cuda-version<=${CUDA_VERSION}" "${cudart_spec}"
+
+    # Install jupyter kernel in this environment
+    "${envpath}/bin/python3" -m pip install ipykernel
+
+    # package environment and cache in GCS
+    pushd "${envpath}"
+    tar czf "${local_tarball}" .
+    popd
+    ${gsutil_cmd} cp "${local_tarball}" "${gcs_tarball}"
+    if ${gsutil_stat_cmd} "${gcs_tarball}.building" ; then ${gsutil_cmd} rm "${gcs_tarball}.building" || true ; fi
+    building_file=""
+  fi
+
+  # register the environment as a selectable kernel
+  "${envpath}/bin/python3" -m ipykernel install --name "${env}" --display-name "Python (${env})"
+
+  mark_complete pytorch
+}
+
 function configure_dkms_certs() {
-  if [[ -z "${PSN}" ]]; then
+  if test -v PSN && [[ -z "${PSN}" ]]; then
       echo "No signing secret provided.  skipping";
       return 0
   fi
@@ -508,27 +884,26 @@ function configure_dkms_certs() {
     echo "Private key material exists"
 
     local expected_modulus_md5sum
-    expected_modulus_md5sum=$(get_metadata_attribute cert_modulus_md5sum)
+    expected_modulus_md5sum=$(get_metadata_attribute modulus_md5sum)
     if [[ -n "${expected_modulus_md5sum}" ]]; then
       modulus_md5sum="${expected_modulus_md5sum}"
+
+      # Verify that cert md5sum matches expected md5sum
+      if [[ "${modulus_md5sum}" != "$(openssl rsa -noout -modulus -in "${CA_TMPDIR}/db.rsa" | openssl md5 | awk '{print $2}')" ]]; then
+        echo "unmatched rsa key"
+      fi
+
+      # Verify that key md5sum matches expected md5sum
+      if [[ "${modulus_md5sum}" != "$(openssl x509 -noout -modulus -in ${mok_der} | openssl md5 | awk '{print $2}')" ]]; then
+        echo "unmatched x509 cert"
+      fi
     else
-      modulus_md5sum="bd40cf5905c7bba4225d330136fdbfd3"
+      modulus_md5sum="$(openssl rsa -noout -modulus -in "${CA_TMPDIR}/db.rsa" | openssl md5 | awk '{print $2}')"
     fi
-
-    # Verify that cert md5sum matches expected md5sum
-    if [[ "${modulus_md5sum}" != "$(openssl rsa -noout -modulus -in \"${CA_TMPDIR}/db.rsa\" | openssl md5 | awk '{print $2}')" ]]; then
-        echo "unmatched rsa key modulus"
-    fi
-    ln -sf "${CA_TMPDIR}/db.rsa" /var/lib/dkms/mok.key
-
-    # Verify that key md5sum matches expected md5sum
-    if [[ "${modulus_md5sum}" != "$(openssl x509 -noout -modulus -in /var/lib/dkms/mok.pub | openssl md5 | awk '{print $2}')" ]]; then
-        echo "unmatched x509 cert modulus"
-    fi
+    ln -sf "${CA_TMPDIR}/db.rsa" "${mok_key}"
 
     return
   fi
-
 
   # Retrieve cloud secrets keys
   local sig_priv_secret_name
@@ -556,16 +931,14 @@ function configure_dkms_certs() {
       | base64 --decode \
       | dd status=none of="${CA_TMPDIR}/db.der"
 
-  # symlink private key and copy public cert from volatile storage for DKMS
-  if is_ubuntu ; then
-    mkdir -p /var/lib/shim-signed/mok
-    ln -sf "${CA_TMPDIR}/db.rsa" /var/lib/shim-signed/mok/MOK.priv
-    cp -f "${CA_TMPDIR}/db.der" /var/lib/shim-signed/mok/MOK.der
-  else
-    mkdir -p /var/lib/dkms/
-    ln -sf "${CA_TMPDIR}/db.rsa" /var/lib/dkms/mok.key
-    cp -f "${CA_TMPDIR}/db.der" /var/lib/dkms/mok.pub
-  fi
+  local mok_directory="$(dirname "${mok_key}")"
+  mkdir -p "${mok_directory}"
+
+  # symlink private key and copy public cert from volatile storage to DKMS directory
+  ln -sf "${CA_TMPDIR}/db.rsa" "${mok_key}"
+  cp  -f "${CA_TMPDIR}/db.der" "${mok_der}"
+
+  modulus_md5sum="$(openssl rsa -noout -modulus -in "${mok_key}" | openssl md5 | awk '{print $2}')"
 }
 
 function clear_dkms_key {
@@ -573,11 +946,12 @@ function clear_dkms_key {
       echo "No signing secret provided.  skipping" >&2
       return 0
   fi
-  rm -rf "${CA_TMPDIR}" /var/lib/dkms/mok.key /var/lib/shim-signed/mok/MOK.priv
+  rm -rf "${CA_TMPDIR}" "${mok_key}"
 }
 
 function add_contrib_component() {
-  if is_debian12 ; then
+  if ! is_debuntu ; then return ; fi
+  if ge_debian12 ; then
       # Include in sources file components on which nvidia-kernel-open-dkms depends
       local -r debian_sources="/etc/apt/sources.list.d/debian.sources"
       local components="main contrib"
@@ -590,7 +964,7 @@ function add_contrib_component() {
 
 function add_nonfree_components() {
   if is_src_nvidia ; then return; fi
-  if is_debian12 ; then
+  if ge_debian12 ; then
       # Include in sources file components on which nvidia-open-kernel-dkms depends
       local -r debian_sources="/etc/apt/sources.list.d/debian.sources"
       local components="main contrib non-free non-free-firmware"
@@ -601,81 +975,153 @@ function add_nonfree_components() {
   fi
 }
 
+#
+# Install package signing key and add corresponding repository
+# https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html
 function add_repo_nvidia_container_toolkit() {
-  if is_debuntu ; then
-      local kr_path=/usr/share/keyrings/nvidia-container-toolkit-keyring.gpg
-      local sources_list_path=/etc/apt/sources.list.d/nvidia-container-toolkit.list
-      # https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html
-      test -f "${kr_path}" ||
-        curl -fsSL https://nvidia.github.io/libnvidia-container/gpgkey \
-          | gpg --dearmor -o "${kr_path}"
+  local nvctk_root="https://nvidia.github.io/libnvidia-container"
+  local signing_key_url="${nvctk_root}/gpgkey"
+  local repo_data
 
-      test -f "${sources_list_path}" ||
-        curl -s -L https://nvidia.github.io/libnvidia-container/stable/deb/nvidia-container-toolkit.list \
-          | perl -pe "s#deb https://#deb [signed-by=${kr_path}] https://#g" \
-          | tee "${sources_list_path}"
+  # Since there are more than one keys to go into this keychain, we can't call os_add_repo, which only works with one
+  if is_debuntu ; then
+    # "${repo_name}" "${signing_key_url}" "${repo_data}" "${4:-yes}" "${kr_path}" "${6:-}"
+    local -r repo_name="nvidia-container-toolkit"
+    local -r kr_path="/usr/share/keyrings/${repo_name}.gpg"
+    execute_with_retries gpg --keyserver keyserver.ubuntu.com \
+      --no-default-keyring --keyring "${kr_path}" \
+      --recv-keys "0xae09fe4bbd223a84b2ccfce3f60f4b3d7fa2af80" "0xeb693b3035cd5710e231e123a4b469963bf863cc" "0xc95b321b61e88c1809c4f759ddcae044f796ecb0"
+    local -r repo_data="${nvctk_root}/stable/deb/\$(ARCH) /"
+    local -r repo_path="/etc/apt/sources.list.d/${repo_name}.list"
+    echo "deb     [signed-by=${kr_path}] ${repo_data}" >  "${repo_path}"
+    echo "deb-src [signed-by=${kr_path}] ${repo_data}" >> "${repo_path}"
+    execute_with_retries apt-get update
+  else
+    repo_data="${nvctk_root}/stable/rpm/nvidia-container-toolkit.repo"
+    os_add_repo nvidia-container-toolkit \
+                "${signing_key_url}" \
+                "${repo_data}" \
+                "no"
   fi
 }
 
 function add_repo_cuda() {
   if is_debuntu ; then
-    local kr_path=/usr/share/keyrings/cuda-archive-keyring.gpg
-    local sources_list_path="/etc/apt/sources.list.d/cuda-${shortname}-x86_64.list"
-echo "deb [signed-by=${kr_path}] https://developer.download.nvidia.com/compute/cuda/repos/${shortname}/x86_64/ /" \
-    | sudo tee "${sources_list_path}"
-    curl "${NVIDIA_BASE_DL_URL}/cuda/repos/${shortname}/x86_64/cuda-archive-keyring.gpg" \
-      -o "${kr_path}"
+    if version_le "${CUDA_VERSION}" 11.6 ; then
+      local kr_path=/usr/share/keyrings/cuda-archive-keyring.gpg
+      local sources_list_path="/etc/apt/sources.list.d/cuda-${shortname}-x86_64.list"
+      echo "deb [signed-by=${kr_path}] https://developer.download.nvidia.com/compute/cuda/repos/${shortname}/x86_64/ /" \
+      | sudo tee "${sources_list_path}"
+
+      gpg --keyserver keyserver.ubuntu.com \
+        --no-default-keyring --keyring "${kr_path}" \
+        --recv-keys "0xae09fe4bbd223a84b2ccfce3f60f4b3d7fa2af80" "0xeb693b3035cd5710e231e123a4b469963bf863cc"
+    else
+      install_cuda_keyring_pkg # 11.7+, 12.0+
+    fi
   elif is_rocky ; then
     execute_with_retries "dnf config-manager --add-repo ${NVIDIA_ROCKY_REPO_URL}"
-    execute_with_retries "dnf clean all"
   fi
 }
 
-readonly uname_r=$(uname -r)
 function build_driver_from_github() {
-  if is_ubuntu ; then
-    mok_key=/var/lib/shim-signed/mok/MOK.priv
-    mok_der=/var/lib/shim-signed/mok/MOK.der
-  else
-    mok_key=/var/lib/dkms/mok.key
-    mok_der=/var/lib/dkms/mok.pub
-  fi
-  workdir=/opt/install-nvidia-driver
-  mkdir -p "${workdir}"
+  # non-GPL driver will have been built on rocky8, or when driver
+  # version is prior to open driver min, or GPU architecture is prior
+  # to Turing
+  if ( is_rocky8 \
+    || version_lt "${DRIVER_VERSION}" "${MIN_OPEN_DRIVER_VER}" \
+    || [[ "$((16#${pci_device_id}))" < "$((16#1E00))" ]] ) ; then return 0 ; fi
   pushd "${workdir}"
   test -d "${workdir}/open-gpu-kernel-modules" || {
     tarball_fn="${DRIVER_VERSION}.tar.gz"
-    curl -fsSL --retry-connrefused --retry 10 --retry-max-time 30 \
+    execute_with_retries curl ${curl_retry_args} \
       "https://github.com/NVIDIA/open-gpu-kernel-modules/archive/refs/tags/${tarball_fn}" \
-      | tar xz
+      \| tar xz
     mv "open-gpu-kernel-modules-${DRIVER_VERSION}" open-gpu-kernel-modules
   }
-  cd open-gpu-kernel-modules
 
-  time make -j$(nproc) modules \
-    >  /var/log/open-gpu-kernel-modules-build.log \
-    2> /var/log/open-gpu-kernel-modules-build_error.log
-  sync
+  local nvidia_ko_path="$(find /lib/modules/$(uname -r)/ -name 'nvidia.ko')"
+  test -n "${nvidia_ko_path}" && test -f "${nvidia_ko_path}" || {
+    local build_tarball="kmod_${_shortname}_${DRIVER_VERSION}.tar.gz"
+    local local_tarball="${workdir}/${build_tarball}"
+    local build_dir
+    if test -v modulus_md5sum && [[ -n "${modulus_md5sum}" ]]
+      then build_dir="${modulus_md5sum}"
+      else build_dir="unsigned" ; fi
 
-  if [[ -n "${PSN}" ]]; then
-    #configure_dkms_certs
-    for module in $(find kernel-open -name '*.ko'); do
-      "/lib/modules/${uname_r}/build/scripts/sign-file" sha256 \
-      "${mok_key}" \
-      "${mok_der}" \
-      "${module}"
-    done
-    #clear_dkms_key
-  fi
+    local gcs_tarball="${pkg_bucket}/nvidia/kmod/${_shortname}/${uname_r}/${build_dir}/${build_tarball}"
 
-  make modules_install \
-    >> /var/log/open-gpu-kernel-modules-build.log \
-    2>> /var/log/open-gpu-kernel-modules-build_error.log
+    if [[ "$(hostname -s)" =~ ^test && "$(nproc)" < 32 ]] ; then
+      # when running with fewer than 32 cores, yield to in-progress build
+      sleep $(( ( RANDOM % 11 ) + 10 ))
+      local output="$(${gsutil_stat_cmd} "${gcs_tarball}.building"|grep '.reation.time')"
+      if [[ "$?" == "0" ]] ; then
+        local build_start_time build_start_epoch timeout_epoch
+        build_start_time="$(echo ${output} | awk -F': +' '{print $2}')"
+        build_start_epoch="$(date -u -d "${build_start_time}" +%s)"
+        timeout_epoch=$((build_start_epoch + 2700)) # 45 minutes
+        while ${gsutil_stat_cmd} "${gcs_tarball}.building" ; do
+          local now_epoch="$(date -u +%s)"
+          if (( now_epoch > timeout_epoch )) ; then
+            # detect unexpected build failure after 45m
+            ${gsutil_cmd} rm "${gcs_tarball}.building" || echo "might have been deleted by a peer"
+            break
+          fi
+          sleep 5m
+        done
+      fi
+    fi
+
+    if ${gsutil_stat_cmd} "${gcs_tarball}" 2>&1 ; then
+      echo "cache hit"
+    else
+      # build the kernel modules
+      touch "${local_tarball}.building"
+      ${gsutil_cmd} cp "${local_tarball}.building" "${gcs_tarball}.building"
+      building_file="${gcs_tarball}.building"
+      pushd open-gpu-kernel-modules
+      install_build_dependencies
+      if ( is_cuda11 && is_ubuntu22 ) ; then
+        echo "Kernel modules cannot be compiled for CUDA 11 on ${_shortname}"
+        exit 1
+      fi
+      execute_with_retries make -j$(nproc) modules \
+        >  kernel-open/build.log \
+        2> kernel-open/build_error.log
+      # Sign kernel modules
+      if [[ -n "${PSN}" ]]; then
+        configure_dkms_certs
+        for module in $(find open-gpu-kernel-modules/kernel-open -name '*.ko'); do
+          "/lib/modules/${uname_r}/build/scripts/sign-file" sha256 \
+          "${mok_key}" \
+          "${mok_der}" \
+          "${module}"
+        done
+        clear_dkms_key
+      fi
+      make modules_install \
+        >>  kernel-open/build.log \
+        2>> kernel-open/build_error.log
+      # Collect build logs and installed binaries
+      tar czvf "${local_tarball}" \
+        "${workdir}/open-gpu-kernel-modules/kernel-open/"*.log \
+        $(find /lib/modules/${uname_r}/ -iname 'nvidia*.ko')
+      ${gsutil_cmd} cp "${local_tarball}" "${gcs_tarball}"
+      if ${gsutil_stat_cmd} "${gcs_tarball}.building" ; then ${gsutil_cmd} rm "${gcs_tarball}.building" || true ; fi
+      building_file=""
+      rm "${local_tarball}"
+      make clean
+      popd
+    fi
+    ${gsutil_cmd} cat "${gcs_tarball}" | tar -C / -xzv
+    depmod -a
+  }
+
   popd
 }
 
 function build_driver_from_packages() {
-  if is_ubuntu || is_debian ; then
+  if is_debuntu ; then
     if [[ -n "$(apt-cache search -n "nvidia-driver-${DRIVER}-server-open")" ]] ; then
       local pkglist=("nvidia-driver-${DRIVER}-server-open") ; else
       local pkglist=("nvidia-driver-${DRIVER}-open") ; fi
@@ -692,52 +1138,173 @@ function build_driver_from_packages() {
     fi
     add_contrib_component
     apt-get update -qq
-    execute_with_retries apt-get install -y -qq --no-install-recommends dkms  \
-    > "${install_log}" 2>&1 || { cat "${install_log}" && exit -4 ; }
-    #configure_dkms_certs
-    time execute_with_retries apt-get install -y -qq --no-install-recommends "${pkglist[@]}" \
-     > "${install_log}" 2>&1 || { cat "${install_log}" && exit -4 ; }
+    execute_with_retries apt-get install -y -qq --no-install-recommends dkms
+    configure_dkms_certs
+    execute_with_retries apt-get install -y -qq --no-install-recommends "${pkglist[@]}"
     sync
 
   elif is_rocky ; then
-    #configure_dkms_certs
-    if time execute_with_retries dnf -y -q module install "nvidia-driver:${DRIVER}-dkms" \
-       > "${install_log}" 2>&1 || { cat "${install_log}" && exit -4 ; } ; then
+    configure_dkms_certs
+    if execute_with_retries dnf -y -q module install "nvidia-driver:${DRIVER}-dkms" ; then
       echo "nvidia-driver:${DRIVER}-dkms installed successfully"
     else
-      time execute_with_retries dnf -y -q module install 'nvidia-driver:latest' \
-      > "${install_log}" 2>&1 || { cat "${install_log}" && exit -4 ; }
+      execute_with_retries dnf -y -q module install 'nvidia-driver:latest'
     fi
     sync
   fi
-  #clear_dkms_key
+  clear_dkms_key
 }
 
 function install_nvidia_userspace_runfile() {
-  if test -f "${download_dir}/userspace-complete" ; then return ; fi
-  curl -fsSL --retry-connrefused --retry 10 --retry-max-time 30 \
-    "${USERSPACE_URL}" -o "${download_dir}/userspace.run"
-  time bash "${download_dir}/userspace.run" --no-kernel-modules --silent --install-libglvnd \
-  > "${install_log}" 2>&1 || { cat "${install_log}" && exit -4 ; }
-  rm -f "${download_dir}/userspace.run"
-  touch "${download_dir}/userspace-complete"
+  # Parameters for NVIDIA-provided Debian GPU driver
+  readonly DEFAULT_USERSPACE_URL="https://us.download.nvidia.com/XFree86/Linux-x86_64/${DRIVER_VERSION}/NVIDIA-Linux-x86_64-${DRIVER_VERSION}.run"
+
+  readonly USERSPACE_URL=$(get_metadata_attribute 'gpu-driver-url' "${DEFAULT_USERSPACE_URL}")
+
+  USERSPACE_FILENAME="$(echo ${USERSPACE_URL} | perl -pe 's{^.+/}{}')"
+  readonly USERSPACE_FILENAME
+
+  # This .run file contains NV's OpenGL implementation as well as
+  # nvidia optimized implementations of the gtk+ 2,3 stack(s) not
+  # including glib (https://docs.gtk.org/glib/), and what appears to
+  # be a copy of the source from the kernel-open directory of for
+  # example DRIVER_VERSION=560.35.03
+  #
+  # https://github.com/NVIDIA/open-gpu-kernel-modules/archive/refs/tags/560.35.03.tar.gz
+  #
+  # wget https://us.download.nvidia.com/XFree86/Linux-x86_64/560.35.03/NVIDIA-Linux-x86_64-560.35.03.run
+  # sh ./NVIDIA-Linux-x86_64-560.35.03.run -x # this will allow you to review the contents of the package without installing it.
+  is_complete userspace && return
+  local local_fn="${tmpdir}/userspace.run"
+
+  cache_fetched_package "${USERSPACE_URL}" \
+                        "${pkg_bucket}/nvidia/${USERSPACE_FILENAME}" \
+                        "${local_fn}"
+
+  local runfile_args
+  runfile_args=""
+  local cache_hit="0"
+  local local_tarball
+
+  # Build nonfree driver on rocky8, or when driver version is prior to
+  # open driver min, or when GPU architecture is prior to Turing
+  if ( is_rocky8 \
+    || version_lt "${DRIVER_VERSION}" "${MIN_OPEN_DRIVER_VER}" \
+    || [[ "$((16#${pci_device_id}))" < "$((16#1E00))" ]] )
+  then
+    local nvidia_ko_path="$(find /lib/modules/$(uname -r)/ -name 'nvidia.ko')"
+    test -n "${nvidia_ko_path}" && test -f "${nvidia_ko_path}" || {
+      local build_tarball="kmod_${_shortname}_${DRIVER_VERSION}_nonfree.tar.gz"
+      local_tarball="${workdir}/${build_tarball}"
+      local build_dir
+      if test -v modulus_md5sum && [[ -n "${modulus_md5sum}" ]]
+        then build_dir="${modulus_md5sum}"
+        else build_dir="unsigned" ; fi
+
+      local gcs_tarball="${pkg_bucket}/nvidia/kmod/${_shortname}/${uname_r}/${build_dir}/${build_tarball}"
+
+      if [[ "$(hostname -s)" =~ ^test && "$(nproc)" < 32 ]] ; then
+        # when running with fewer than 32 cores, yield to in-progress build
+        sleep $(( ( RANDOM % 11 ) + 10 ))
+        local output="$(${gsutil_stat_cmd} "${gcs_tarball}.building"|grep '.reation.time')"
+        if [[ "$?" == "0" ]] ; then
+          local build_start_time build_start_epoch timeout_epoch
+          build_start_time="$(echo ${output} | awk -F': +' '{print $2}')"
+          build_start_epoch="$(date -u -d "${build_start_time}" +%s)"
+          timeout_epoch=$((build_start_epoch + 2700)) # 45 minutes
+          while ${gsutil_stat_cmd} "${gcs_tarball}.building" ; do
+            local now_epoch="$(date -u +%s)"
+            if (( now_epoch > timeout_epoch )) ; then
+              # detect unexpected build failure after 45m
+              ${gsutil_cmd} rm "${gcs_tarball}.building"
+              break
+            fi
+            sleep 5m
+          done
+        fi
+      fi
+
+      if ${gsutil_stat_cmd} "${gcs_tarball}" ; then
+        cache_hit="1"
+        if version_ge "${DRIVER_VERSION}" "${MIN_OPEN_DRIVER_VER}" ; then
+          runfile_args="${runfile_args} --no-kernel-modules"
+        fi
+        echo "cache hit"
+      else
+        # build the kernel modules
+        touch "${local_tarball}.building"
+        ${gsutil_cmd} cp "${local_tarball}.building" "${gcs_tarball}.building"
+        building_file="${gcs_tarball}.building"
+        install_build_dependencies
+        configure_dkms_certs
+        local signing_options
+        signing_options=""
+        if [[ -n "${PSN}" ]]; then
+          signing_options="--module-signing-hash sha256 \
+          --module-signing-x509-hash sha256 \
+          --module-signing-secret-key \"${mok_key}\" \
+          --module-signing-public-key \"${mok_der}\" \
+          --module-signing-script \"/lib/modules/${uname_r}/build/scripts/sign-file\" \
+          "
+        fi
+        runfile_args="${signing_options}"
+        if version_ge "${DRIVER_VERSION}" "${MIN_OPEN_DRIVER_VER}" ; then
+          runfile_args="${runfile_args} --no-dkms"
+        fi
+      fi
+    }
+  elif version_ge "${DRIVER_VERSION}" "${MIN_OPEN_DRIVER_VER}" ; then
+    runfile_args="--no-kernel-modules"
+  fi
+
+  execute_with_retries bash "${local_fn}" -e -q \
+    ${runfile_args} \
+    --ui=none \
+    --install-libglvnd \
+    --tmpdir="${tmpdir}"
+
+  # On rocky8, or when driver version is prior to open driver min, or when GPU architecture is prior to Turing
+  if ( is_rocky8 \
+    || version_lt "${DRIVER_VERSION}" "${MIN_OPEN_DRIVER_VER}" \
+    || [[ "$((16#${pci_device_id}))" < "$((16#1E00))" ]] ) ; then
+    if [[ "${cache_hit}" == "1" ]] ; then
+      ${gsutil_cmd} cat "${gcs_tarball}" | tar -C / -xzv
+      depmod -a
+    else
+      clear_dkms_key
+      tar czvf "${local_tarball}" \
+        /var/log/nvidia-installer.log \
+        $(find /lib/modules/${uname_r}/ -iname 'nvidia*.ko')
+      ${gsutil_cmd} cp "${local_tarball}" "${gcs_tarball}"
+
+      if ${gsutil_stat_cmd} "${gcs_tarball}.building" ; then ${gsutil_cmd} rm "${gcs_tarball}.building" || true ; fi
+      building_file=""
+    fi
+  fi
+
+  rm -f "${local_fn}"
+  mark_complete userspace
   sync
 }
 
 function install_cuda_runfile() {
-  if test -f "${download_dir}/cuda-complete" ; then return ; fi
-  time curl -fsSL --retry-connrefused --retry 10 --retry-max-time 30 \
-    "${NVIDIA_CUDA_URL}" -o "${download_dir}/cuda.run"
-  time bash "${download_dir}/cuda.run" --silent --toolkit --no-opengl-libs \
-  > "${install_log}" 2>&1 || { cat "${install_log}" && exit -4 ; }
-  rm -f "${download_dir}/cuda.run"
-  touch "${download_dir}/cuda-complete"
+  is_complete cuda && return
+
+  local local_fn="${tmpdir}/cuda.run"
+
+  cache_fetched_package "${NVIDIA_CUDA_URL}" \
+                        "${pkg_bucket}/nvidia/${CUDA_RUNFILE}" \
+                        "${local_fn}"
+
+  execute_with_retries bash "${local_fn}" --toolkit --no-opengl-libs --silent --tmpdir="${tmpdir}"
+  rm -f "${local_fn}"
+  mark_complete cuda
   sync
 }
 
 function install_cuda_toolkit() {
   local cudatk_package=cuda-toolkit
-  if is_debian12 && is_src_os ; then
+  if ge_debian12 && is_src_os ; then
     cudatk_package="${cudatk_package}=${CUDA_FULL_VERSION}-1"
   elif [[ -n "${CUDA_VERSION}" ]]; then
     cudatk_package="${cudatk_package}-${CUDA_VERSION//./-}"
@@ -746,114 +1313,140 @@ function install_cuda_toolkit() {
   readonly cudatk_package
   if is_debuntu ; then
 #    if is_ubuntu ; then execute_with_retries "apt-get install -y -qq --no-install-recommends cuda-drivers-${DRIVER}=${DRIVER_VERSION}-1" ; fi
-    time execute_with_retries apt-get install -y -qq --no-install-recommends ${cuda_package} ${cudatk_package} \
-    > "${install_log}" 2>&1 || { cat "${install_log}" ; exit -4 ; }
-     sync
+    execute_with_retries apt-get install -y -qq --no-install-recommends ${cuda_package} ${cudatk_package}
   elif is_rocky ; then
-    time execute_with_retries dnf -y -q install "${cudatk_package}" \
-    > "${install_log}" 2>&1 || { cat "${install_log}" && exit -4 ; }
-    sync
+    # rocky9: cuda-11-[7,8], cuda-12-[1..6]
+    execute_with_retries dnf -y -q install "${cudatk_package}"
   fi
-}
-
-function install_drivers_aliases() {
-  if is_rocky ; then return ; fi
-  if ! (is_debian12 || is_debian11) ; then return ; fi
-  if (is_debian12 && is_cuda11) && is_src_nvidia ; then return ; fi # don't install on debian 12 / cuda11 with drivers from nvidia
-  # Add a modprobe alias to prefer the open kernel modules
-  local conffile="/etc/modprobe.d/nvidia-aliases.conf"
-  echo -n "" > "${conffile}"
-  local prefix
-  if   is_src_os     ; then prefix="nvidia-current-open"
-  elif is_src_nvidia ; then prefix="nvidia-current" ; fi
-  local suffix
-  for suffix in uvm peermem modeset drm; do
-    echo "alias nvidia-${suffix} ${prefix}-${suffix}" >> "${conffile}"
-  done
-  echo "alias nvidia ${prefix}" >> "${conffile}"
+  sync
 }
 
 function load_kernel_module() {
   # for some use cases, the kernel module needs to be removed before first use of nvidia-smi
   for module in nvidia_uvm nvidia_drm nvidia_modeset nvidia ; do
-    rmmod ${module} > /dev/null 2>&1 || echo "unable to rmmod ${module}"
+    ( set +e
+      rmmod ${module} > /dev/null 2>&1 || echo "unable to rmmod ${module}"
+    )
   done
 
-  install_drivers_aliases
   depmod -a
   modprobe nvidia
+  for suffix in uvm modeset drm; do
+    modprobe "nvidia-${suffix}"
+  done
+  # TODO: if peermem is available, also modprobe nvidia-peermem
+}
+
+function install_cuda(){
+  is_complete cuda-repo && return
+  if [[ "${gpu_count}" == "0" ]] ; then return ; fi
+
+  if ( ge_debian12 && is_src_os ) ; then
+    echo "installed with the driver on ${_shortname}"
+    return 0
+  fi
+
+  # The OS package distributions are unreliable
+  install_cuda_runfile
+
+  # Includes CUDA packages
+  add_repo_cuda
+
+  mark_complete cuda-repo
+}
+
+function install_nvidia_container_toolkit() {
+  is_complete install-nvctk && return
+
+  local container_runtime_default
+    if command -v docker     ; then container_runtime_default='docker'
+  elif command -v containerd ; then container_runtime_default='containerd'
+  elif command -v crio       ; then container_runtime_default='crio'
+                               else container_runtime_default='' ; fi
+  CONTAINER_RUNTIME=$(get_metadata_attribute 'container-runtime' "${container_runtime_default}")
+
+  if test -z "${CONTAINER_RUNTIME}" ; then return ; fi
+
+  add_repo_nvidia_container_toolkit
+  if is_debuntu ; then
+    execute_with_retries apt-get install -y -q nvidia-container-toolkit ; else
+    execute_with_retries dnf     install -y -q nvidia-container-toolkit ; fi
+  nvidia-ctk runtime configure --runtime="${CONTAINER_RUNTIME}"
+  systemctl restart "${CONTAINER_RUNTIME}"
+
+  mark_complete install-nvctk
 }
 
 # Install NVIDIA GPU driver provided by NVIDIA
 function install_nvidia_gpu_driver() {
-  if is_debian12 && is_src_os ; then
+  is_complete gpu-driver && return
+  if [[ "${gpu_count}" == "0" ]] ; then return ; fi
+
+  if ( ge_debian12 && is_src_os ) ; then
     add_nonfree_components
-    add_repo_nvidia_container_toolkit
     apt-get update -qq
-    #configure_dkms_certs
     apt-get -yq install \
-          nvidia-container-toolkit \
-          dkms \
-          nvidia-open-kernel-dkms \
-          nvidia-open-kernel-support \
-          nvidia-smi \
-          libglvnd0 \
-          libcuda1
-    #clear_dkms_key
-    load_kernel_module
-  elif is_ubuntu18 || is_debian10 || (is_debian12 && is_cuda11) ; then
-
-    install_nvidia_userspace_runfile
-
-    build_driver_from_github
-
-    load_kernel_module
-
-    install_cuda_runfile
-  elif is_debuntu ; then
-    install_cuda_keyring_pkg
-
-    build_driver_from_packages
-
-    load_kernel_module
-
-    install_cuda_toolkit
-  elif is_rocky ; then
-    add_repo_cuda
-
-    build_driver_from_packages
-
-    load_kernel_module
-
-    install_cuda_toolkit
-
-  else
-    echo "Unsupported OS: '${OS_NAME}'"
-    exit 1
+        dkms \
+        nvidia-open-kernel-dkms \
+        nvidia-open-kernel-support \
+        nvidia-smi \
+        libglvnd0 \
+        libcuda1
+    echo "NVIDIA GPU driver provided by ${_shortname} was installed successfully"
+    return 0
   fi
-  ldconfig
-  if is_src_os ; then
-    echo "NVIDIA GPU driver provided by ${OS_NAME} was installed successfully"
-  else
-    echo "NVIDIA GPU driver provided by NVIDIA was installed successfully"
-  fi
+
+  # OS driver packages do not produce reliable driver ; use runfile
+  install_nvidia_userspace_runfile
+
+  build_driver_from_github
+
+  echo "NVIDIA GPU driver provided by NVIDIA was installed successfully"
+  mark_complete gpu-driver
+}
+
+function install_ops_agent(){
+  is_complete ops-agent && return
+
+  mkdir -p /opt/google
+  cd /opt/google
+  # https://cloud.google.com/stackdriver/docs/solutions/agents/ops-agent/installation
+  curl ${curl_retry_args} -O https://dl.google.com/cloudagents/add-google-cloud-ops-agent-repo.sh
+  local expected="038d98644e4c4a7969d26da790946720d278c8d49bb82b677f550c2a2b858411  add-google-cloud-ops-agent-repo.sh"
+
+  execute_with_retries bash add-google-cloud-ops-agent-repo.sh --also-install
+
+  mark_complete ops-agent
 }
 
 # Collects 'gpu_utilization' and 'gpu_memory_utilization' metrics
 function install_gpu_agent() {
-  if ! command -v pip; then
-    execute_with_retries "apt-get install -y -qq python-pip"
+  # Stackdriver GPU agent parameters
+#  local -r GPU_AGENT_REPO_URL='https://raw.githubusercontent.com/GoogleCloudPlatform/ml-on-gcp/master/dlvm/gcp-gpu-utilization-metrics'
+  local -r GPU_AGENT_REPO_URL='https://raw.githubusercontent.com/GoogleCloudPlatform/ml-on-gcp/refs/heads/master/dlvm/gcp-gpu-utilization-metrics'
+  if ( ! command -v pip && is_debuntu ) ; then
+    execute_with_retries "apt-get install -y -qq python3-pip"
   fi
   local install_dir=/opt/gpu-utilization-agent
   mkdir -p "${install_dir}"
-  curl -fsSL --retry-connrefused --retry 10 --retry-max-time 30 \
+  curl ${curl_retry_args} \
     "${GPU_AGENT_REPO_URL}/requirements.txt" -o "${install_dir}/requirements.txt"
-  curl -fsSL --retry-connrefused --retry 10 --retry-max-time 30 \
+  curl ${curl_retry_args} \
     "${GPU_AGENT_REPO_URL}/report_gpu_metrics.py" \
     | sed -e 's/-u --format=/--format=/' \
     | dd status=none of="${install_dir}/report_gpu_metrics.py"
-  time execute_with_retries pip install -r "${install_dir}/requirements.txt" \
-  > "${install_log}" 2>&1 || { cat "${install_log}" && exit -4 ; }
+  local venv="${install_dir}/venv"
+  python_interpreter="/opt/conda/miniconda3/bin/python3"
+  [[ -f "${python_interpreter}" ]] || python_interpreter="$(command -v python3)"
+  if version_ge "${DATAPROC_IMAGE_VERSION}" "2.2" && is_debuntu ; then
+    execute_with_retries "apt-get install -y -qq python3-venv"
+  fi
+  "${python_interpreter}" -m venv "${venv}"
+(
+  source "${venv}/bin/activate"
+  python3 -m pip install --upgrade pip
+  execute_with_retries python3 -m pip install -r "${install_dir}/requirements.txt"
+)
   sync
 
   # Generate GPU service.
@@ -864,7 +1457,7 @@ Description=GPU Utilization Metric Agent
 [Service]
 Type=simple
 PIDFile=/run/gpu_agent.pid
-ExecStart=/bin/bash --login -c 'python "${install_dir}/report_gpu_metrics.py"'
+ExecStart=/bin/bash --login -c '. ${venv}/bin/activate ; python3 "${install_dir}/report_gpu_metrics.py"'
 User=root
 Group=root
 WorkingDirectory=/
@@ -889,8 +1482,14 @@ function set_hadoop_property() {
     --clobber
 }
 
-function configure_yarn() {
-  if [[ -d "${HADOOP_CONF_DIR}" && ! -f "${HADOOP_CONF_DIR}/resource-types.xml" ]]; then
+function configure_yarn_resources() {
+  if [[ ! -d "${HADOOP_CONF_DIR}" ]] ; then
+    # TODO: when running this script to customize an image, this file
+    # needs to be written *after* bdutil completes
+
+    return 0
+  fi # pre-init scripts
+  if [[ ! -f "${HADOOP_CONF_DIR}/resource-types.xml" ]]; then
     printf '<?xml version="1.0" ?>\n<configuration/>' >"${HADOOP_CONF_DIR}/resource-types.xml"
   fi
   set_hadoop_property 'resource-types.xml' 'yarn.resource-types' 'yarn.io/gpu'
@@ -904,11 +1503,12 @@ function configure_yarn() {
 
 # This configuration should be applied only if GPU is attached to the node
 function configure_yarn_nodemanager() {
-  set_hadoop_property 'yarn-site.xml' 'yarn.nodemanager.resource-plugins' 'yarn.io/gpu'
+  set_hadoop_property 'yarn-site.xml' \
+    'yarn.nodemanager.resource-plugins' 'yarn.io/gpu'
   set_hadoop_property 'yarn-site.xml' \
     'yarn.nodemanager.resource-plugins.gpu.allowed-gpu-devices' 'auto'
   set_hadoop_property 'yarn-site.xml' \
-    'yarn.nodemanager.resource-plugins.gpu.path-to-discovery-executables' $NVIDIA_SMI_PATH
+    'yarn.nodemanager.resource-plugins.gpu.path-to-discovery-executables' "${NVIDIA_SMI_PATH}"
   set_hadoop_property 'yarn-site.xml' \
     'yarn.nodemanager.linux-container-executor.cgroups.mount' 'true'
   set_hadoop_property 'yarn-site.xml' \
@@ -916,9 +1516,9 @@ function configure_yarn_nodemanager() {
   set_hadoop_property 'yarn-site.xml' \
     'yarn.nodemanager.linux-container-executor.cgroups.hierarchy' 'yarn'
   set_hadoop_property 'yarn-site.xml' \
-    'yarn.nodemanager.container-executor.class' \
-    'org.apache.hadoop.yarn.server.nodemanager.LinuxContainerExecutor'
-  set_hadoop_property 'yarn-site.xml' 'yarn.nodemanager.linux-container-executor.group' 'yarn'
+    'yarn.nodemanager.container-executor.class' 'org.apache.hadoop.yarn.server.nodemanager.LinuxContainerExecutor'
+  set_hadoop_property 'yarn-site.xml' \
+    'yarn.nodemanager.linux-container-executor.group' 'yarn'
 
   # Fix local dirs access permissions
   local yarn_local_dirs=()
@@ -933,20 +1533,17 @@ function configure_yarn_nodemanager() {
 }
 
 function configure_gpu_exclusive_mode() {
-  # check if running spark 3, if not, enable GPU exclusive mode
-  local spark_version
-  spark_version=$(spark-submit --version 2>&1 | sed -n 's/.*version[[:blank:]]\+\([0-9]\+\.[0-9]\).*/\1/p' | head -n1)
-  if [[ ${spark_version} != 3.* ]]; then
-    # include exclusive mode on GPU
-    nvsmi -c EXCLUSIVE_PROCESS
-  fi
+  # only run this function when spark < 3.0
+  if version_ge "${SPARK_VERSION}" "3.0" ; then return 0 ; fi
+  # include exclusive mode on GPU
+  nvsmi -c EXCLUSIVE_PROCESS
 }
 
 function fetch_mig_scripts() {
   mkdir -p /usr/local/yarn-mig-scripts
   sudo chmod 755 /usr/local/yarn-mig-scripts
-  wget -P /usr/local/yarn-mig-scripts/ https://raw.githubusercontent.com/NVIDIA/spark-rapids-examples/branch-22.10/examples/MIG-Support/yarn-unpatched/scripts/nvidia-smi
-  wget -P /usr/local/yarn-mig-scripts/ https://raw.githubusercontent.com/NVIDIA/spark-rapids-examples/branch-22.10/examples/MIG-Support/yarn-unpatched/scripts/mig2gpu.sh
+  execute_with_retries wget -P /usr/local/yarn-mig-scripts/ https://raw.githubusercontent.com/NVIDIA/spark-rapids-examples/branch-22.10/examples/MIG-Support/yarn-unpatched/scripts/nvidia-smi
+  execute_with_retries wget -P /usr/local/yarn-mig-scripts/ https://raw.githubusercontent.com/NVIDIA/spark-rapids-examples/branch-22.10/examples/MIG-Support/yarn-unpatched/scripts/mig2gpu.sh
   sudo chmod 755 /usr/local/yarn-mig-scripts/*
 }
 
@@ -957,7 +1554,8 @@ function configure_gpu_script() {
   # need to update the getGpusResources.sh script to look for MIG devices since if multiple GPUs nvidia-smi still
   # lists those because we only disable the specific GIs via CGROUPs. Here we just create it based off of:
   # https://raw.githubusercontent.com/apache/spark/master/examples/src/main/scripts/getGpusResources.sh
-  cat > ${spark_gpu_script_dir}/getGpusResources.sh <<'EOF'
+  local -r gpus_resources_script="${spark_gpu_script_dir}/getGpusResources.sh"
+  cat > "${gpus_resources_script}" <<'EOF'
 #!/usr/bin/env bash
 
 #
@@ -976,35 +1574,73 @@ function configure_gpu_script() {
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+# Example output: {"name": "gpu", "addresses":["0","1","2","3","4","5","6","7"]}
 
-CACHE_FILE="/var/run/nvidia-gpu-index.txt"
-if [[ -f "${CACHE_FILE}" ]]; then
-  cat "${CACHE_FILE}"
-  exit 0
-fi
-NV_SMI_L_CACHE_FILE="/var/run/nvidia-smi_-L.txt"
-if [[ -f "${NV_SMI_L_CACHE_FILE}" ]]; then
-  NVIDIA_SMI_L="$(cat "${NV_SMI_L_CACHE_FILE}")"
-else
-  NVIDIA_SMI_L="$(nvidia-smi -L | tee "${NV_SMI_L_CACHE_FILE}")"
-fi
+set -e
+resources_json="/dev/shm/nvidia/gpusResources.json"
+if test -f "${resources_json}" ; then cat "${resources_json}" ; exit 0 ; fi
 
-NUM_MIG_DEVICES=$(echo "${NVIDIA_SMI_L}" | grep -e MIG -e H100 -e A100 | wc -l || echo '0')
+mkdir -p "$(dirname ${resources_json})"
 
-if [[ "${NUM_MIG_DEVICES}" -gt "0" ]] ; then
-  MIG_INDEX=$(( $NUM_MIG_DEVICES - 1 ))
-  ADDRS="$(perl -e 'print(join(q{,},map{qq{"$_"}}(0..$ARGV[0])),$/)' "${MIG_INDEX}")"
-else
-  ADDRS=$(nvidia-smi --query-gpu=index --format=csv,noheader | perl -e 'print(join(q{,},map{chomp; qq{"$_"}}<STDIN>))')
-fi
+ADDRS=$(nvidia-smi --query-gpu=index --format=csv,noheader | perl -e 'print(join(q{,},map{chomp; qq{"$_"}}<STDIN>))')
 
-echo {\"name\": \"gpu\", \"addresses\":[$ADDRS]} | tee "${CACHE_FILE}"
+echo {\"name\": \"gpu\", \"addresses\":[${ADDRS}]} | tee "${resources_json}"
 EOF
 
-  chmod a+rwx -R ${spark_gpu_script_dir}
+  chmod a+rx "${gpus_resources_script}"
+
+  if version_lt "${SPARK_VERSION}" "3.0" ; then return ; fi
+
+  local spark_defaults_conf="/etc/spark/conf.dist/spark-defaults.conf"
+  local spark_defaults_dir="$(dirname "${spark_defaults_conf}")"
+  if ! grep spark.executor.resource.gpu.discoveryScript "${spark_defaults_conf}" ; then
+    echo "spark.executor.resource.gpu.discoveryScript=${gpus_resources_script}" >> "${spark_defaults_conf}"
+  fi
+  local executor_cores
+  executor_cores="$(nproc | perl -MPOSIX -pe '$_ = POSIX::floor( $_ * 0.75 ); $_-- if $_ % 2')"
+  [[ "${executor_cores}" == "0" ]] && executor_cores=1
+  local executor_memory
+  executor_memory_gb="$(awk '/^MemFree/ {print $2}' /proc/meminfo | perl -MPOSIX -pe '$_ *= 0.75; $_ = POSIX::floor( $_ / (1024*1024) )')"
+  local task_cpus=2
+  [[ "${task_cpus}" -gt "${executor_cores}" ]] && task_cpus="${executor_cores}"
+  local gpu_amount
+#  gpu_amount="$(echo $executor_cores | perl -pe "\$_ = ( ${gpu_count} / (\$_ / ${task_cpus}) )")"
+  gpu_amount="$(perl -e "print 1 / ${executor_cores}")"
+
+  # the gpu.amount properties are not appropriate for the version of
+  # spark shipped with 1.5 images using the capacity scheduler.  TODO:
+  # In order to get spark rapids GPU accelerated SQL working on 1.5
+  # images, we must configure the Fair scheduler
+  version_ge "${DATAPROC_IMAGE_VERSION}" "2.0" || return
+
+  if ! grep -q "BEGIN : RAPIDS properties" "${spark_defaults_conf}"; then
+    cat >>"${spark_defaults_conf}" <<EOF
+###### BEGIN : RAPIDS properties for Spark ${SPARK_VERSION} ######
+# Rapids Accelerator for Spark can utilize AQE, but when the plan is not finalized,
+# query explain output won't show GPU operator, if the user has doubts
+# they can uncomment the line before seeing the GPU plan explain;
+# having AQE enabled gives user the best performance.
+#spark.sql.autoBroadcastJoinThreshold=10m
+#spark.sql.files.maxPartitionBytes=512m
+spark.executor.resource.gpu.amount=1
+#spark.executor.cores=${executor_cores}
+#spark.executor.memory=${executor_memory_gb}G
+#spark.dynamicAllocation.enabled=false
+# please update this config according to your application
+#spark.task.resource.gpu.amount=${gpu_amount}
+#spark.task.cpus=2
+#spark.yarn.unmanagedAM.enabled=false
+#spark.plugins=com.nvidia.spark.SQLPlugin
+###### END   : RAPIDS properties for Spark ${SPARK_VERSION} ######
+EOF
+  fi
 }
 
 function configure_gpu_isolation() {
+  if [[ ! -d "${HADOOP_CONF_DIR}" ]]; then
+     echo "Hadoop conf dir ${HADOOP_CONF_DIR} not found. Skipping GPU isolation config."
+     return
+  fi
   # enable GPU isolation
   sed -i "s/yarn\.nodemanager\.linux\-container\-executor\.group\=.*$/yarn\.nodemanager\.linux\-container\-executor\.group\=yarn/g" "${HADOOP_CONF_DIR}/container-executor.cfg"
   if [[ $IS_MIG_ENABLED -ne 0 ]]; then
@@ -1034,89 +1670,504 @@ EOF
 
 function nvsmi() {
   local nvsmi="/usr/bin/nvidia-smi"
-  if   [[ "${nvsmi_works}" == "1" ]] ; then echo "nvidia-smi is working" >&2
+  if   [[ "${nvsmi_works}" == "1" ]] ; then echo -n ''
   elif [[ ! -f "${nvsmi}" ]]         ; then echo "nvidia-smi not installed" >&2 ; return 0
   elif ! eval "${nvsmi} > /dev/null" ; then echo "nvidia-smi fails" >&2 ; return 0
   else nvsmi_works="1" ; fi
 
-  if [[ "$1" == "-L" ]] ; then
+  if test -v 1 && [[ "$1" == "-L" ]] ; then
     local NV_SMI_L_CACHE_FILE="/var/run/nvidia-smi_-L.txt"
     if [[ -f "${NV_SMI_L_CACHE_FILE}" ]]; then cat "${NV_SMI_L_CACHE_FILE}"
     else "${nvsmi}" $* | tee "${NV_SMI_L_CACHE_FILE}" ; fi
-
     return 0
   fi
 
   "${nvsmi}" $*
 }
 
-function main() {
-  if ! is_debian && ! is_ubuntu && ! is_rocky ; then
-    echo "Unsupported OS: '$(os_name)'"
-    exit 1
-  fi
-
-  remove_old_backports
+function install_build_dependencies() {
+  is_complete build-dependencies && return
 
   if is_debuntu ; then
-    export DEBIAN_FRONTEND=noninteractive
-    time execute_with_retries apt-get install -y -qq pciutils "linux-headers-${uname_r}" > /dev/null 2>&1
+    if is_ubuntu22 && is_cuda12 ; then
+      # On ubuntu22, the default compiler does not build some kernel module versions
+      # https://forums.developer.nvidia.com/t/linux-new-kernel-6-5-0-14-ubuntu-22-04-can-not-compile-nvidia-display-card-driver/278553/11
+      execute_with_retries apt-get install -y -qq gcc-12
+      update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-11 11
+      update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-12 12
+      update-alternatives --set gcc /usr/bin/gcc-12
+    elif is_ubuntu22 && version_lt "${CUDA_VERSION}" "11.7" ; then
+      # On cuda less than 11.7, the kernel driver does not build on ubuntu22
+      # https://forums.developer.nvidia.com/t/latest-nvidia-driver-470-63-01-installation-fails-with-latest-linux-kernel-5-16-5-100/202972
+      echo "N.B.: Older CUDA 11 known bad on ${_shortname}"
+    fi
+
   elif is_rocky ; then
-    time execute_with_retries dnf -y -q update --exclude=systemd*,kernel* \
-    > "${install_log}" 2>&1 || { cat "${install_log}" && exit -4 ; }
-    time execute_with_retries dnf -y -q install pciutils gcc \
-    > "${install_log}" 2>&1 || { cat "${install_log}" && exit -4 ; }
+    execute_with_retries dnf -y -q install gcc
 
     local dnf_cmd="dnf -y -q install kernel-devel-${uname_r}"
-    local kernel_devel_pkg_out="$(eval "${dnf_cmd} 2>&1")"
-    if [[ "${kernel_devel_pkg_out}" =~ 'Unable to find a match: kernel-devel-' ]] ; then
+    set +e
+    eval "${dnf_cmd}" > "${install_log}" 2>&1
+    local retval="$?"
+    set -e
+
+    if [[ "${retval}" == "0" ]] ; then return ; fi
+
+    local os_ver="$(echo $uname_r | perl -pe 's/.*el(\d+_\d+)\..*/$1/; s/_/./')"
+    local vault="https://download.rockylinux.org/vault/rocky/${os_ver}"
+    if grep -q 'Unable to find a match: kernel-devel-' "${install_log}" ; then
       # this kernel-devel may have been migrated to the vault
-      local vault="https://download.rockylinux.org/vault/rocky/$(os_version)"
-      time execute_with_retries dnf -y -q --setopt=localpkg_gpgcheck=1 install \
+      dnf_cmd="$(echo dnf -y -q --setopt=localpkg_gpgcheck=1 install \
         "${vault}/BaseOS/x86_64/os/Packages/k/kernel-${uname_r}.rpm" \
         "${vault}/BaseOS/x86_64/os/Packages/k/kernel-core-${uname_r}.rpm" \
         "${vault}/BaseOS/x86_64/os/Packages/k/kernel-modules-${uname_r}.rpm" \
         "${vault}/BaseOS/x86_64/os/Packages/k/kernel-modules-core-${uname_r}.rpm" \
-        "${vault}/AppStream/x86_64/os/Packages/k/kernel-devel-${uname_r}.rpm" \
-	> "${install_log}" 2>&1 || { cat "${install_log}" ; exit -4 ; }
-      sync
-    else
-      execute_with_retries "${dnf_cmd}"
+        "${vault}/AppStream/x86_64/os/Packages/k/kernel-devel-${uname_r}.rpm"
+       )"
     fi
+
+    set +e
+    eval "${dnf_cmd}" > "${install_log}" 2>&1
+    local retval="$?"
+    set -e
+
+    if [[ "${retval}" == "0" ]] ; then return ; fi
+
+    if grep -q 'Status code: 404 for https' "${install_log}" ; then
+      local stg_url="https://download.rockylinux.org/stg/rocky/${os_ver}/devel/x86_64/os/Packages/k/"
+      dnf_cmd="$(echo dnf -y -q --setopt=localpkg_gpgcheck=1 install \
+        "${stg_url}/kernel-${uname_r}.rpm" \
+        "${stg_url}/kernel-core-${uname_r}.rpm" \
+        "${stg_url}/kernel-modules-${uname_r}.rpm" \
+        "${stg_url}/kernel-modules-core-${uname_r}.rpm" \
+        "${stg_url}/kernel-devel-${uname_r}.rpm"
+       )"
+    fi
+
+    execute_with_retries "${dnf_cmd}"
+  fi
+  mark_complete build-dependencies
+}
+
+function is_complete() {
+  phase="$1"
+  test -f "${workdir}/complete/${phase}"
+}
+
+function mark_complete() {
+  phase="$1"
+  touch "${workdir}/complete/${phase}"
+}
+
+function mark_incomplete() {
+  phase="$1"
+  rm -f "${workdir}/complete/${phase}"
+}
+
+function install_dependencies() {
+  is_complete install-dependencies && return 0
+
+  pkg_list="pciutils screen"
+  if is_debuntu ; then execute_with_retries apt-get -y -q install ${pkg_list}
+  elif is_rocky ; then execute_with_retries dnf     -y -q install ${pkg_list} ; fi
+  mark_complete install-dependencies
+}
+
+function prepare_gpu_env(){
+  #set_support_matrix
+
+  # if set, this variable includes a gcs path to a build-in-progress indicator
+  building_file=""
+
+  set_cuda_version
+  set_driver_version
+
+  set +e
+  # NV vendor ID is 10DE
+  pci_vendor_id="10DE"
+  gpu_count="$(grep -i PCI_ID=${pci_vendor_id} /sys/bus/pci/devices/*/uevent | wc -l)"
+  set -e
+
+  if [[ "${gpu_count}" > "0" ]] ; then
+    # N.B.: https://pci-ids.ucw.cz/v2.2/pci.ids.xz
+    pci_device_id="$(grep -h -i PCI_ID=10DE /sys/bus/pci/devices/*/uevent | head -1 | awk -F: '{print $2}')"
+    pci_device_id_int="$((16#${pci_device_id}))"
+    case "${pci_device_id}" in
+      "15F8" ) gpu_type="nvidia-tesla-p100"      ;;
+      "1BB3" ) gpu_type="nvidia-tesla-p4"        ;;
+      "1DB1" ) gpu_type="nvidia-tesla-v100"      ;;
+      "1EB8" ) gpu_type="nvidia-tesla-t4"        ;;
+      "20B2" ) gpu_type="nvidia-tesla-a100-80gb" ;;
+      "20B5" ) gpu_type="nvidia-tesla-a100-80gb" ;;
+      "20F3" ) gpu_type="nvidia-tesla-a100-80gb" ;;
+      "20F5" ) gpu_type="nvidia-tesla-a100-80gb" ;;
+      "20"*  ) gpu_type="nvidia-tesla-a100"      ;;
+      "23"*  ) gpu_type="nvidia-h100"            ;; # NB: install does not begin with legacy image 2.0.68-debian10/cuda11.1
+      "27B8" ) gpu_type="nvidia-l4"              ;; # NB: install does not complete with legacy image 2.0.68-debian10/cuda11.1
+      *      ) gpu_type="unrecognized"
+    esac
+
+    ACCELERATOR="type=${gpu_type},count=${gpu_count}"
   fi
 
-  # This configuration should be run on all nodes
-  # regardless if they have attached GPUs
-  configure_yarn
+  nvsmi_works="0"
 
-  # Detect NVIDIA GPU
+  if   is_cuda11 ; then gcc_ver="11"
+  elif is_cuda12 ; then gcc_ver="12" ; fi
+
+  if ! test -v DEFAULT_RAPIDS_RUNTIME ; then
+    readonly DEFAULT_RAPIDS_RUNTIME='SPARK'
+  fi
+
+  # Set variables from metadata
+  RAPIDS_RUNTIME=$(get_metadata_attribute 'rapids-runtime' 'SPARK')
+  INCLUDE_GPUS="$(get_metadata_attribute include-gpus "")"
+  INCLUDE_PYTORCH="$(get_metadata_attribute 'include-pytorch' 'no')"
+  readonly RAPIDS_RUNTIME INCLUDE_GPUS INCLUDE_PYTORCH
+
+  # determine whether we have nvidia-smi installed and working
+  nvsmi
+
+  set_nv_urls
+  set_cuda_runfile_url
+  set_cudnn_version
+  set_cudnn_tarball_url
+}
+
+# Hold all NVIDIA-related packages from upgrading unintenionally or services like unattended-upgrades
+# Users should run apt-mark unhold before they wish to upgrade these packages
+function hold_nvidia_packages() {
+  if ! is_debuntu ; then return ; fi
+
+  apt-mark hold nvidia-*    > /dev/null 2>&1
+  apt-mark hold libnvidia-* > /dev/null 2>&1
+  if dpkg -l | grep -q "xserver-xorg-video-nvidia"; then
+    apt-mark hold xserver-xorg-video-nvidia*
+  fi
+}
+
+function check_secure_boot() {
+  local SECURE_BOOT="disabled"
+  if command -v mokutil ; then
+      SECURE_BOOT=$(mokutil --sb-state|awk '{print $2}')
+  fi
+
+  PSN="$(get_metadata_attribute private_secret_name)"
+  readonly PSN
+
+  if [[ "${SECURE_BOOT}" == "enabled" ]] && le_debian11 ; then
+    echo "Error: Secure Boot is not supported on Debian before image 2.2. Please disable Secure Boot while creating the cluster."
+    exit 1
+  elif [[ "${SECURE_BOOT}" == "enabled" ]] && [[ -z "${PSN}" ]]; then
+    echo "Error: Secure boot is enabled, but no signing material provided."
+    echo "Please either disable secure boot or provide signing material as per"
+    echo "https://github.com/GoogleCloudDataproc/custom-images/tree/master/examples/secure-boot"
+    return 1
+  fi
+
+  CA_TMPDIR="$(mktemp -u -d -p /run/tmp -t ca_dir-XXXX)"
+  readonly CA_TMPDIR
+
+  if is_ubuntu ; then mok_key=/var/lib/shim-signed/mok/MOK.priv
+                      mok_der=/var/lib/shim-signed/mok/MOK.der
+                 else mok_key=/var/lib/dkms/mok.key
+                      mok_der=/var/lib/dkms/mok.pub ; fi
+  return 0
+}
+
+# Function to group Hadoop/Spark config steps (called in init-action mode or deferred)
+function run_hadoop_spark_config() {
+  # Ensure necessary variables are available or re-evaluated
+  # prepare_gpu_env needs CUDA/Driver versions, call it first if needed
+  if [[ ! -v CUDA_VERSION || ! -v DRIVER_VERSION ]]; then prepare_gpu_env; fi
+  # Re-read ROLE
+  ROLE="$(get_metadata_attribute dataproc-role)";
+  # Re-read SPARK_VERSION if not set or default
+  if [[ ! -v SPARK_VERSION || "${SPARK_VERSION}" == "0.0" ]]; then
+      SPARK_VERSION="$(spark-submit --version 2>&1 | sed -n 's/.*version[[:blank:]]\+\([0-9]\+\.[0-9]\).*/\1/p' | head -n1 || echo "0.0")"
+  fi
+  # Re-check GPU count
+  set +e
+  gpu_count="$(grep -i PCI_ID=10DE /sys/bus/pci/devices/*/uevent | wc -l)"
+  set -e
+  # Re-check MIG status
+  IS_MIG_ENABLED=0
+  NVIDIA_SMI_PATH='/usr/bin' # Reset default path
+  MIG_MAJOR_CAPS=0
+  if [[ "${gpu_count}" -gt "0" ]] && nvsmi >/dev/null 2>&1; then # Check if nvsmi works before querying
+      migquery_result="$(nvsmi --query-gpu=mig.mode.current --format=csv,noheader || echo '[N/A]')"
+      if [[ "${migquery_result}" != "[N/A]" && "${migquery_result}" != "" ]]; then
+          NUM_MIG_GPUS="$(echo ${migquery_result} | uniq | wc -l)"
+          if [[ "${NUM_MIG_GPUS}" -eq "1" ]] && (echo "${migquery_result}" | grep -q Enabled); then
+            IS_MIG_ENABLED=1
+            NVIDIA_SMI_PATH='/usr/local/yarn-mig-scripts/' # Set MIG path
+            MIG_MAJOR_CAPS=$(grep nvidia-caps /proc/devices | cut -d ' ' -f 1 || echo 0)
+            if [[ ! -d "/usr/local/yarn-mig-scripts" ]]; then fetch_mig_scripts || echo "WARN: Failed to fetch MIG scripts." >&2; fi
+          fi
+      fi
+  fi
+
+  # Ensure config directories exist
+  if [[ ! -d "${HADOOP_CONF_DIR}" || ! -d "${SPARK_CONF_DIR}" ]]; then
+     echo "ERROR: Config directories (${HADOOP_CONF_DIR}, ${SPARK_CONF_DIR}) not found. Cannot apply configuration."
+     return 1 # Use return instead of exit in a function
+  fi
+
+  # Run config applicable to all nodes
+  configure_yarn_resources
+
+  # Run node-specific config
+  if [[ "${gpu_count}" -gt 0 ]]; then
+    configure_yarn_nodemanager
+    install_spark_rapids # Installs JARs
+    configure_gpu_script
+    configure_gpu_isolation
+    configure_gpu_exclusive_mode # Call this here, it checks Spark version internally
+  elif [[ "${ROLE}" == "Master" ]]; then
+    # Master node without GPU still needs some config
+    configure_yarn_nodemanager
+    install_spark_rapids # Still need JARs on Master
+    configure_gpu_script
+  else
+    # Worker node without GPU, skip node-specific YARN/Spark config.
+    :
+  fi
+
+  # Restart services after config
+  for svc in resourcemanager nodemanager; do
+    if (systemctl is-active --quiet hadoop-yarn-${svc}.service); then
+      systemctl stop  hadoop-yarn-${svc}.service || echo "WARN: Failed to stop ${svc}"
+      systemctl start hadoop-yarn-${svc}.service || echo "WARN: Failed to start ${svc}"
+    fi
+  done
+  return 0 # Explicitly return success
+}
+
+# This function now ONLY generates the script and service file.
+# It does NOT enable the service here.
+function create_deferred_config_files() {
+  local -r service_name="dataproc-gpu-config"
+  local -r service_file="/etc/systemd/system/${service_name}.service"
+  # This is the script that will contain the config logic
+  local -r config_script_path="/usr/local/sbin/apply-dataproc-gpu-config.sh"
+
+  # Use 'declare -f' to extract function definitions needed by the config logic
+  # and write them, along with the config logic itself, into the new script.
+  cat <<EOF > "${config_script_path}"
+#!/bin/bash
+# Deferred configuration script generated by install_gpu_driver.sh
+set -xeuo pipefail
+
+# --- Minimal necessary functions and variables ---
+# Define constants
+readonly HADOOP_CONF_DIR='/etc/hadoop/conf'
+readonly SPARK_CONF_DIR='/etc/spark/conf'
+readonly bdcfg="/usr/local/bin/bdconfig"
+readonly workdir=/opt/install-dpgce # Needed for cache_fetched_package
+
+# --- Define Necessary Global Arrays ---
+# These need to be explicitly defined here as they are not functions.
+$(declare -p DRIVER_FOR_CUDA)
+$(declare -p DRIVER_SUBVER)
+$(declare -p CUDNN_FOR_CUDA)
+$(declare -p NCCL_FOR_CUDA)
+$(declare -p CUDA_SUBVER)
+# drv_for_cuda is defined within set_cuda_runfile_url, which is included below
+
+# Define minimal metadata functions
+$(declare -f print_metadata_value)
+$(declare -f print_metadata_value_if_exists)
+$(declare -f get_metadata_value)
+$(declare -f get_metadata_attribute)
+
+# Define nvsmi wrapper
+$(declare -f nvsmi)
+nvsmi_works="0" # Initialize variable used by nvsmi
+
+# Define version comparison
+$(declare -f version_ge)
+$(declare -f version_gt)
+$(declare -f version_le)
+$(declare -f version_lt)
+
+# Define OS check functions
+$(declare -f os_id)
+$(declare -f os_version)
+$(declare -f os_codename) # Added os_codename as it's used by clean_up_sources_lists indirectly via os_add_repo
+$(declare -f is_debian)
+$(declare -f is_ubuntu)
+$(declare -f is_rocky)
+$(declare -f is_debuntu)
+$(declare -f is_debian10)
+$(declare -f is_debian11)
+$(declare -f is_debian12)
+$(declare -f is_rocky8)
+$(declare -f is_rocky9)
+$(declare -f is_ubuntu18)
+$(declare -f is_ubuntu20)
+$(declare -f is_ubuntu22)
+$(declare -f ge_debian12)
+$(declare -f le_debian10)
+$(declare -f le_debian11)
+$(declare -f ge_ubuntu20)
+$(declare -f le_ubuntu18)
+$(declare -f ge_rocky9)
+$(declare -f os_vercat) # Added os_vercat as it's used by set_nv_urls/set_cuda_runfile_url
+# Define _shortname (needed by install_spark_rapids -> cache_fetched_package and others)
+readonly _shortname="\$(os_id)\$(os_version|perl -pe 's/(\\d+).*/\$1/')"
+# Define shortname and nccl_shortname (needed by set_nv_urls)
+if is_ubuntu22  ; then
+    nccl_shortname="ubuntu2004"
+    shortname="\$(os_id)\$(os_vercat)"
+elif ge_rocky9 ; then
+    nccl_shortname="rhel8"
+    shortname="rhel9"
+elif is_rocky ; then
+    shortname="\$(os_id | sed -e 's/rocky/rhel/')\$(os_vercat)"
+    nccl_shortname="\${shortname}"
+else
+    shortname="\$(os_id)\$(os_vercat)"
+    nccl_shortname="\${shortname}"
+fi
+readonly shortname nccl_shortname
+
+# Define prepare_gpu_env and its dependencies
+$(declare -f prepare_gpu_env)
+$(declare -f set_cuda_version)
+$(declare -f set_driver_version)
+$(declare -f set_nv_urls)
+$(declare -f set_cuda_runfile_url)
+$(declare -f set_cudnn_version)
+$(declare -f set_cudnn_tarball_url)
+$(declare -f is_cuda11)
+$(declare -f is_cuda12)
+$(declare -f le_cuda11)
+$(declare -f le_cuda12)
+$(declare -f ge_cuda11)
+$(declare -f ge_cuda12)
+$(declare -f is_cudnn8)
+$(declare -f is_cudnn9)
+
+# Define DATAPROC_IMAGE_VERSION (re-evaluate)
+SPARK_VERSION="\$(spark-submit --version 2>&1 | sed -n 's/.*version[[:blank:]]\+\([0-9]\+\.[0-9]\).*/\1/p' | head -n1 || echo "0.0")"
+if   version_lt "\${SPARK_VERSION}" "2.5" ; then DATAPROC_IMAGE_VERSION="1.5"
+elif version_lt "\${SPARK_VERSION}" "3.2" ; then DATAPROC_IMAGE_VERSION="2.0"
+elif version_lt "\${SPARK_VERSION}" "3.4" ; then DATAPROC_IMAGE_VERSION="2.1"
+elif version_lt "\${SPARK_VERSION}" "3.6" ; then
+  if [[ -f /etc/environment ]] ; then
+    eval "\$(grep '^DATAPROC_IMAGE_VERSION' /etc/environment)" || DATAPROC_IMAGE_VERSION="2.2"
+  else
+    DATAPROC_IMAGE_VERSION="2.2"
+  fi
+else DATAPROC_IMAGE_VERSION="2.3" ; fi # Default to latest known version
+readonly DATAPROC_IMAGE_VERSION
+
+# Define set_hadoop_property
+$(declare -f set_hadoop_property)
+
+# --- Include definitions of functions called by the config logic ---
+$(declare -f configure_yarn_resources)
+$(declare -f configure_yarn_nodemanager)
+$(declare -f install_spark_rapids)
+$(declare -f configure_gpu_script)
+$(declare -f configure_gpu_isolation)
+$(declare -f configure_gpu_exclusive_mode)
+$(declare -f fetch_mig_scripts)
+$(declare -f cache_fetched_package)
+$(declare -f execute_with_retries)
+
+# --- Define gsutil/gcloud commands and curl args ---
+gsutil_cmd="gcloud storage"
+gsutil_stat_cmd="gcloud storage objects describe"
+gcloud_sdk_version="\$(gcloud --version | awk -F'SDK ' '/Google Cloud SDK/ {print \$2}' || echo '0.0.0')"
+if version_lt "\${gcloud_sdk_version}" "402.0.0" ; then
+  gsutil_cmd="gsutil -o GSUtil:check_hashes=never"
+  gsutil_stat_cmd="gsutil stat"
+fi
+curl_retry_args="-fsSL --retry-connrefused --retry 10 --retry-max-time 30"
+# Define pkg_bucket (needed by cache_fetched_package)
+temp_bucket="\$(get_metadata_attribute dataproc-temp-bucket)"
+readonly temp_bucket
+readonly pkg_bucket="gs://\${temp_bucket}/dpgce-packages"
+readonly install_log="/tmp/deferred-config-install.log" # Log file for execute_with_retries
+
+# --- Include the main config function ---
+$(declare -f run_hadoop_spark_config)
+
+# --- Execute the config logic ---
+if run_hadoop_spark_config; then
+  # Configuration successful, disable the service
+  systemctl disable ${service_name}.service
+  rm -f "${config_script_path}" "${service_file}"
+  systemctl daemon-reload
+else
+  echo "ERROR: Deferred configuration script (${config_script_path}) failed." >&2
+  # Keep the service enabled to allow for manual inspection/retry
+  exit 1
+fi
+
+exit 0
+EOF
+
+  chmod +x "${config_script_path}"
+
+  cat <<EOF > "${service_file}"
+[Unit]
+Description=Apply Dataproc GPU configuration on first boot
+# Ensure it runs after Dataproc agent and YARN services are likely up
+After=google-dataproc-agent.service network-online.target hadoop-yarn-resourcemanager.service hadoop-yarn-nodemanager.service
+Wants=network-online.target google-dataproc-agent.service
+
+[Service]
+Type=oneshot
+ExecStart=${config_script_path} # Execute the generated config script
+RemainAfterExit=no # Service is done after exec
+StandardOutput=journal+console
+StandardError=journal+console
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+  chmod 644 "${service_file}"
+  # Service is enabled later only if IS_CUSTOM_IMAGE_BUILD is true
+}
+
+function main() {
+  # Perform installations (these are generally safe during image build)
   if (lspci | grep -q NVIDIA); then
-    # if this is called without the MIG script then the drivers are not installed
-    migquery_result="$(nvsmi --query-gpu=mig.mode.current --format=csv,noheader)"
+    # Check MIG status early, primarily for driver installation logic
+    migquery_result="$(nvsmi --query-gpu=mig.mode.current --format=csv,noheader || echo '[N/A]')" # Use || for safety
     if [[ "${migquery_result}" == "[N/A]" ]] ; then migquery_result="" ; fi
     NUM_MIG_GPUS="$(echo ${migquery_result} | uniq | wc -l)"
 
-    if [[ "${NUM_MIG_GPUS}" -gt "0" ]] ; then
+    if [[ "${NUM_MIG_GPUS}" -gt 0 ]] ; then
       if [[ "${NUM_MIG_GPUS}" -eq "1" ]]; then
         if (echo "${migquery_result}" | grep Enabled); then
           IS_MIG_ENABLED=1
-          NVIDIA_SMI_PATH='/usr/local/yarn-mig-scripts/'
-          MIG_MAJOR_CAPS=`grep nvidia-caps /proc/devices | cut -d ' ' -f 1`
-          fetch_mig_scripts
+          # Fetch MIG scripts early if needed by driver install/check
+          if [[ ! -d "/usr/local/yarn-mig-scripts" ]]; then fetch_mig_scripts || echo "WARN: Failed to fetch MIG scripts." >&2; fi
         fi
       fi
     fi
 
-    # if mig is enabled drivers would have already been installed
+    # Install core components if MIG is not already enabled (MIG setup implies drivers exist)
     if [[ $IS_MIG_ENABLED -eq 0 ]]; then
       install_nvidia_gpu_driver
+      install_nvidia_container_toolkit
+      install_cuda
+      load_kernel_module # Load modules after driver install
 
       if [[ -n ${CUDNN_VERSION} ]]; then
         install_nvidia_nccl
         install_nvidia_cudnn
       fi
+      case "${INCLUDE_PYTORCH^^}" in
+        "1" | "YES" | "TRUE" ) install_pytorch ;;
+      esac
       #Install GPU metrics collection in Stackdriver if needed
       if [[ "${INSTALL_GPU_AGENT}" == "true" ]]; then
+        #install_ops_agent
         install_gpu_agent
         echo 'GPU metrics agent successfully deployed.'
       else
@@ -1128,18 +2179,24 @@ function main() {
         rmmod ${module} > /dev/null 2>&1 || echo "unable to rmmod ${module}"
       done
 
-      MIG_GPU_LIST="$(nvsmi -L | grep -e MIG -e H100 -e A100 || echo -n "")"
       if test -n "$(nvsmi -L)" ; then
-	# cache the result of the gpu query
+        # cache the result of the gpu query
         ADDRS=$(nvsmi --query-gpu=index --format=csv,noheader | perl -e 'print(join(q{,},map{chomp; qq{"$_"}}<STDIN>))')
         echo "{\"name\": \"gpu\", \"addresses\":[$ADDRS]}" | tee "/var/run/nvidia-gpu-index.txt"
+        chmod a+r "/var/run/nvidia-gpu-index.txt"
       fi
+      MIG_GPU_LIST="$(nvsmi -L | grep -E '(MIG|[PVAH]100)' || echo -n "")"
       NUM_MIG_GPUS="$(test -n "${MIG_GPU_LIST}" && echo "${MIG_GPU_LIST}" | wc -l || echo "0")"
       if [[ "${NUM_MIG_GPUS}" -gt "0" ]] ; then
         # enable MIG on every GPU
-	for GPU_ID in $(echo ${MIG_GPU_LIST} | awk -F'[: ]' -e '{print $2}') ; do
-	  nvsmi -i "${GPU_ID}" --multi-instance-gpu 1
-	done
+        for GPU_ID in $(echo ${MIG_GPU_LIST} | awk -F'[: ]' '{print $2}') ; do
+          if version_le "${CUDA_VERSION}" "11.6" ; then
+            nvsmi -i "${GPU_ID}" --multi-instance-gpu=1
+          else
+            nvsmi -i "${GPU_ID}" --multi-instance-gpu 1
+
+          fi
+        done
 
         NVIDIA_SMI_PATH='/usr/local/yarn-mig-scripts/'
         MIG_MAJOR_CAPS="$(grep nvidia-caps /proc/devices | cut -d ' ' -f 1)"
@@ -1150,23 +2207,54 @@ function main() {
     fi
 
     configure_yarn_nodemanager
+    install_spark_rapids
     configure_gpu_script
     configure_gpu_isolation
   elif [[ "${ROLE}" == "Master" ]]; then
-    configure_yarn_nodemanager
-    configure_gpu_script
-  fi
+    # Master node without GPU detected.
+    :
+  else
+    # Worker node without GPU detected.
+    :
+  fi # End GPU detection
 
-  # Restart YARN services if they are running already
-  if [[ $(systemctl show hadoop-yarn-resourcemanager.service -p SubState --value) == 'running' ]]; then
-    systemctl restart hadoop-yarn-resourcemanager.service
+  # --- Generate Config Script and Service File ---
+  # This happens in both modes now
+  create_deferred_config_files
+
+  # --- Apply or Defer Configuration ---
+  if [[ "${IS_CUSTOM_IMAGE_BUILD}" == "true" ]]; then
+    # Enable the systemd service for first boot
+    systemctl enable "dataproc-gpu-config.service"
+  else
+    # Running as a standard init action: execute the generated script immediately
+    local -r config_script_path="/usr/local/sbin/apply-dataproc-gpu-config.sh"
+    if [[ -x "${config_script_path}" ]]; then
+        bash -x "${config_script_path}"
+    else
+        echo "ERROR: Generated config script ${config_script_path} not found or not executable."
+        exit 1
+    fi
+    # The config script handles its own cleanup and service disabling on success
   fi
-  if [[ $(systemctl show hadoop-yarn-nodemanager.service -p SubState --value) == 'running' ]]; then
-    systemctl restart hadoop-yarn-nodemanager.service
+  # --- End Apply or Defer ---
+}
+
+function cache_fetched_package() {
+  local src_url="$1"
+  local gcs_fn="$2"
+  local local_fn="$3"
+
+  if ${gsutil_stat_cmd} "${gcs_fn}" 2>&1 ; then
+    execute_with_retries ${gsutil_cmd} cp "${gcs_fn}" "${local_fn}"
+  else
+    time ( curl ${curl_retry_args} "${src_url}" -o "${local_fn}" && \
+           execute_with_retries ${gsutil_cmd} cp "${local_fn}" "${gcs_fn}" ; )
   fi
 }
 
 function clean_up_sources_lists() {
+  if ! is_debuntu; then return; fi
   #
   # bigtop (primary)
   #
@@ -1177,8 +2265,8 @@ function clean_up_sources_lists() {
 
     local regional_bigtop_repo_uri
     regional_bigtop_repo_uri=$(cat ${dataproc_repo_file} |
-      sed "s#/dataproc-bigtop-repo/#/goog-dataproc-bigtop-repo-${region}/#" |
-      grep "deb .*goog-dataproc-bigtop-repo-${region}.* dataproc contrib" |
+      sed -E "s#/dataproc-bigtop-repo(-dev)?/#/goog-dataproc-bigtop-repo\\1-${region}/#" |
+      grep -E "deb .*goog-dataproc-bigtop-repo(-dev)?-${region}.* dataproc contrib" |
       cut -d ' ' -f 2 |
       head -1)
 
@@ -1190,7 +2278,7 @@ function clean_up_sources_lists() {
 
     local -r bigtop_kr_path="/usr/share/keyrings/bigtop-keyring.gpg"
     rm -f "${bigtop_kr_path}"
-    curl -fsS --retry-connrefused --retry 10 --retry-max-time 30 \
+    curl ${curl_retry_args} \
       "${bigtop_key_uri}" | gpg --dearmor -o "${bigtop_kr_path}"
 
     sed -i -e "s:deb https:deb [signed-by=${bigtop_kr_path}] https:g" "${dataproc_repo_file}"
@@ -1204,11 +2292,16 @@ function clean_up_sources_lists() {
   local -r key_url="https://packages.adoptium.net/artifactory/api/gpg/key/public"
   local -r adoptium_kr_path="/usr/share/keyrings/adoptium.gpg"
   rm -f "${adoptium_kr_path}"
-  curl -fsS --retry-connrefused --retry 10 --retry-max-time 30 "${key_url}" \
-   | gpg --dearmor -o "${adoptium_kr_path}"
+  local -r old_adoptium_list="/etc/apt/sources.list.d/adoptopenjdk.list"
+  if test -f "${old_adoptium_list}" ; then
+    rm -f "${old_adoptium_list}"
+  fi
+  for keyid in "0x3b04d753c9050d9a5d343f39843c48a565f8f04b" "0x35baa0b33e9eb396f59ca838c0ba5ce6dc6315a3" ; do
+    curl ${curl_retry_args} "https://keyserver.ubuntu.com/pks/lookup?op=get&search=${keyid}" \
+    | gpg --import --no-default-keyring --keyring "${adoptium_kr_path}"
+  done
   echo "deb [signed-by=${adoptium_kr_path}] https://packages.adoptium.net/artifactory/deb/ $(os_codename) main" \
    > /etc/apt/sources.list.d/adoptium.list
-
 
   #
   # docker
@@ -1218,21 +2311,23 @@ function clean_up_sources_lists() {
   local -r docker_key_url="https://download.docker.com/linux/$(os_id)/gpg"
 
   rm -f "${docker_kr_path}"
-  curl -fsS --retry-connrefused --retry 10 --retry-max-time 30 "${docker_key_url}" \
-    | gpg --dearmor -o "${docker_kr_path}"
+  curl ${curl_retry_args} "${docker_key_url}" \
+    | gpg --import --no-default-keyring --keyring "${docker_kr_path}"
   echo "deb [signed-by=${docker_kr_path}] https://download.docker.com/linux/$(os_id) $(os_codename) stable" \
     > ${docker_repo_file}
 
   #
   # google cloud + logging/monitoring
   #
-  if ls /etc/apt/sources.list.d/google-cloud*.list ; then
-    rm -f /usr/share/keyrings/cloud.google.gpg
-    curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | gpg --dearmor -o /usr/share/keyrings/cloud.google.gpg
+  local gcloud_kr_path="/usr/share/keyrings/cloud.google.gpg"
+  if ls /etc/apt/sources.list.d/google-clou*.list ; then
+    rm -f "${gcloud_kr_path}"
+    curl ${curl_retry_args} https://packages.cloud.google.com/apt/doc/apt-key.gpg \
+      | gpg --import --no-default-keyring --keyring "${gcloud_kr_path}"
     for list in google-cloud google-cloud-logging google-cloud-monitoring ; do
       list_file="/etc/apt/sources.list.d/${list}.list"
       if [[ -f "${list_file}" ]]; then
-        sed -i -e 's:deb https:deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https:g' "${list_file}"
+        sed -i -e "s:deb https:deb [signed-by=${gcloud_kr_path}] https:g" "${list_file}"
       fi
     done
   fi
@@ -1241,10 +2336,13 @@ function clean_up_sources_lists() {
   # cran-r
   #
   if [[ -f /etc/apt/sources.list.d/cran-r.list ]]; then
-    rm -f /usr/share/keyrings/cran-r.gpg
-    curl 'https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x95c0faf38db3ccad0c080a7bdc78b2ddeabc47b7' | \
-      gpg --dearmor -o /usr/share/keyrings/cran-r.gpg
-    sed -i -e 's:deb http:deb [signed-by=/usr/share/keyrings/cran-r.gpg] http:g' /etc/apt/sources.list.d/cran-r.list
+    local cranr_kr_path="/usr/share/keyrings/cran-r.gpg"
+    rm -f "${cranr_kr_path}"
+    for keyid in "0x95c0faf38db3ccad0c080a7bdc78b2ddeabc47b7" "0xe298a3a825c0d65dfd57cbb651716619e084dab9" ; do
+      curl ${curl_retry_args} "https://keyserver.ubuntu.com/pks/lookup?op=get&search=${keyid}" \
+      | gpg --import --no-default-keyring --keyring "${cranr_kr_path}"
+    done
+    sed -i -e "s:deb http:deb [signed-by=${cranr_kr_path}] http:g" /etc/apt/sources.list.d/cran-r.list
   fi
 
   #
@@ -1252,7 +2350,7 @@ function clean_up_sources_lists() {
   #
   if [[ -f /etc/apt/sources.list.d/mysql.list ]]; then
     rm -f /usr/share/keyrings/mysql.gpg
-    curl 'https://keyserver.ubuntu.com/pks/lookup?op=get&search=0xBCA43417C3B485DD128EC6D4B7B3B788A8D3785C' | \
+    curl ${curl_retry_args} 'https://keyserver.ubuntu.com/pks/lookup?op=get&search=0xBCA43417C3B485DD128EC6D4B7B3B788A8D3785C' | \
       gpg --dearmor -o /usr/share/keyrings/mysql.gpg
     sed -i -e 's:deb https:deb [signed-by=/usr/share/keyrings/mysql.gpg] https:g' /etc/apt/sources.list.d/mysql.list
   fi
@@ -1262,134 +2360,413 @@ function clean_up_sources_lists() {
 }
 
 function exit_handler() {
-  echo "Exit handler invoked"
-  set +ex
   # Purge private key material until next grant
   clear_dkms_key
 
-  # Free conda cache
-  /opt/conda/miniconda3/bin/conda clean -a
+  # clean up incomplete build indicators
+  if test -n "${building_file}" ; then
+    if ${gsutil_stat_cmd} "${building_file}" ; then ${gsutil_cmd} rm "${building_file}" || true ; fi
+  fi
+
+  set +e # Allow cleanup commands to fail without exiting script
+  echo "Exit handler invoked"
 
   # Clear pip cache
+  # TODO: make this conditional on which OSs have pip without cache purge
   pip cache purge || echo "unable to purge pip cache"
 
-  # remove the tmpfs conda pkgs_dirs
-  if [[ -d /mnt/shm ]] ; then /opt/conda/miniconda3/bin/conda config --remove pkgs_dirs /mnt/shm ; fi
 
-  # remove the tmpfs pip cache-dir
-  pip config unset global.cache-dir || echo "unable to set global pip cache"
+  # If system memory was sufficient to mount memory-backed filesystems
+  if [[ "${tmpdir}" == "/mnt/shm" ]] ; then
+    # remove the tmpfs pip cache-dir
+    pip config unset global.cache-dir || echo "unable to unset global pip cache"
 
-  # Clean up shared memory mounts
-  for shmdir in /mnt/shm /var/cache/apt/archives /var/cache/dnf ; do
-    if grep -q "^tmpfs ${shmdir}" /proc/mounts ; then
-      rm -rf ${shmdir}/*
-      sync
+    # Clean up shared memory mounts
+    for shmdir in /var/cache/apt/archives /var/cache/dnf /mnt/shm /tmp /var/cudnn-local ; do
+      if ( grep -q "^tmpfs ${shmdir}" /proc/mounts && ! grep -q "^tmpfs ${shmdir}" /etc/fstab ) ; then
+        umount -f ${shmdir}
+      fi
+    done
 
-      execute_with_retries umount -f ${shmdir}
-    fi
-  done
+    # restart services stopped during preparation stage
+    # systemctl list-units | perl -n -e 'qx(systemctl start $1) if /^.*? ((hadoop|knox|hive|mapred|yarn|hdfs)\S*).service/'
+  fi
 
-  # Clean up OS package cache ; re-hold systemd package
   if is_debuntu ; then
+    # Clean up OS package cache
     apt-get -y -qq clean
-    apt-get -y -qq autoremove
-    if is_debian12 ; then
+    apt-get -y -qq -o DPkg::Lock::Timeout=60 autoremove
+    # re-hold systemd package
+    if ge_debian12 ; then
     apt-mark hold systemd libsystemd0 ; fi
+    hold_nvidia_packages
   else
     dnf clean all
   fi
 
-  # print disk usage statistics
-  if is_debuntu ; then
-    # Rocky doesn't have sort -h and fails when the argument is passed
-    du --max-depth 3 -hx / | sort -h | tail -10
+  # print disk usage statistics for large components
+  if is_ubuntu ; then
+    du -hs \
+      /usr/lib/{pig,hive,hadoop,jvm,spark,google-cloud-sdk,x86_64-linux-gnu} \
+      /usr/lib \
+      /opt/nvidia/* \
+      /opt/conda/miniconda3 2>/dev/null | sort -h
+  elif is_debian ; then
+    du -x -hs \
+      /usr/lib/{pig,hive,hadoop,jvm,spark,google-cloud-sdk,x86_64-linux-gnu,} \
+      /var/lib/{docker,mysql,} \
+      /opt/nvidia/* \
+      /opt/{conda,google-cloud-ops-agent,install-nvidia,} \
+      /usr/bin \
+      /usr \
+      /var \
+      / 2>/dev/null | sort -h
+  else # Rocky
+    du -hs \
+      /var/lib/docker \
+      /usr/lib/{pig,hive,hadoop,firmware,jvm,spark,atlas,} \
+      /usr/lib64/google-cloud-sdk \
+      /opt/nvidia/* \
+      /opt/conda/miniconda3 2>/dev/null | sort -h
   fi
 
   # Process disk usage logs from installation period
-  rm -f /tmp/keep-running-df
-  sleep 6s
+  rm -f /run/keep-running-df
+  sync
+  sleep 5.01s
   # compute maximum size of disk during installation
   # Log file contains logs like the following (minus the preceeding #):
-#Filesystem      Size  Used Avail Use% Mounted on
-#/dev/vda2       6.8G  2.5G  4.0G  39% /
-  df --si
-  perl -e '$max=( sort
-                   map { (split)[2] =~ /^(\d+)/ }
-                  grep { m:^/: } <STDIN> )[-1];
-print( "maximum-disk-used: $max", $/ );' < /tmp/disk-usage.log
+#Filesystem     1K-blocks    Used Available Use% Mounted on
+#/dev/vda2        7096908 2611344   4182932  39% /
+  df / | tee -a "/run/disk-usage.log"
+
+  perl -e '($first, @samples) = grep { m:^/: } <STDIN>;
+           unshift(@samples,$first); $final=$samples[-1];
+           ($starting)=(split(/\s+/,$first))[2] =~ /^(\d+)/;
+             ($ending)=(split(/\s+/,$final))[2] =~ /^(\d+)/;
+           @siz=( sort { $a <= $b }
+                   map { (split)[2] =~ /^(\d+)/ } @samples );
+$max=$siz[0]; $min=$siz[-1]; $inc=$max-$starting;
+print( "     samples-taken: ", scalar @siz, $/,
+       "starting-disk-used: $starting", $/,
+       "  ending-disk-used: $ending", $/,
+       " maximum-disk-used: $max", $/,
+       " minimum-disk-used: $min", $/,
+       "      increased-by: $inc", $/ )' < "/run/disk-usage.log"
 
   echo "exit_handler has completed"
 
-  # zero free disk space
-  if [[ -n "$(get_metadata_attribute creating-image)" ]]; then
-    dd if=/dev/zero of=/zero ; sync ; rm -f /zero
+  # zero free disk space (only if creating image)
+  if [[ "${IS_CUSTOM_IMAGE_BUILD}" == "true" ]]; then
+    dd if=/dev/zero of=/zero status=progress || true
+    sync
+    sleep 3s
+    rm -f /zero || true
   fi
 
   return 0
 }
 
-trap exit_handler EXIT
+function set_proxy(){
+  METADATA_HTTP_PROXY="$(get_metadata_attribute http-proxy '')"
+
+  if [[ -z "${METADATA_HTTP_PROXY}" ]] ; then return ; fi
+
+  export http_proxy="${METADATA_HTTP_PROXY}"
+  export https_proxy="${METADATA_HTTP_PROXY}"
+  export HTTP_PROXY="${METADATA_HTTP_PROXY}"
+  export HTTPS_PROXY="${METADATA_HTTP_PROXY}"
+  no_proxy="localhost,127.0.0.0/8,::1,metadata.google.internal,169.254.169.254"
+  local no_proxy_svc
+  for no_proxy_svc in compute  secretmanager dns    servicedirectory     logging  \
+                      bigquery composer      pubsub bigquerydatatransfer dataflow \
+                      storage  datafusion    ; do
+    no_proxy="${no_proxy},${no_proxy_svc}.googleapis.com"
+  done
+
+  export NO_PROXY="${no_proxy}"
+}
+
+function mount_ramdisk(){
+  local free_mem
+  free_mem="$(awk '/^MemFree/ {print $2}' /proc/meminfo)"
+  if [[ ${free_mem} -lt 20500000 ]]; then return 0 ; fi
+
+  # Write to a ramdisk instead of churning the persistent disk
+  tmpdir="/mnt/shm"
+  mkdir -p "${tmpdir}/pkgs_dirs"
+  mount -t tmpfs tmpfs "${tmpdir}"
+
+  # Download conda packages to tmpfs
+  if [[ -f /opt/conda/miniconda3/bin/conda ]] ; then
+    /opt/conda/miniconda3/bin/conda config --add pkgs_dirs "${tmpdir}"
+  fi
+
+  # Clear pip cache
+  # TODO: make this conditional on which OSs have pip without cache purge
+  pip cache purge || echo "unable to purge pip cache"
+
+  # Download pip packages to tmpfs
+  pip config set global.cache-dir "${tmpdir}" || echo "unable to set global.cache-dir"
+
+  # Download OS packages to tmpfs
+  if is_debuntu ; then
+    mount -t tmpfs tmpfs /var/cache/apt/archives
+  else
+    mount -t tmpfs tmpfs /var/cache/dnf
+  fi
+}
+
+function harden_sshd_config() {
+  # disable sha1 and md5 use in kex and kex-gss features
+  declare -A feature_map=(["kex"]="kexalgorithms")
+  if ( is_rocky || version_ge "${DATAPROC_IMAGE_VERSION}" "2.1" ) ; then
+    feature_map["kex-gss"]="gssapikexalgorithms"
+  fi
+  for ftr in "${!feature_map[@]}" ; do
+    local feature=${feature_map[$ftr]}
+    local sshd_config_line
+    sshd_config_line="${feature} $(
+      (sshd -T | awk "/^${feature} / {print \$2}" | sed -e 's/,/\n/g';
+       ssh -Q "${ftr}" ) \
+      | sort -u | grep -v -ie sha1 -e md5 | paste -sd "," -)"
+
+    grep -iv "^${feature} " /etc/ssh/sshd_config > /tmp/sshd_config_new
+    echo "$sshd_config_line" >> /tmp/sshd_config_new
+    # TODO: test whether sshd will reload with this change before mv
+    mv -f /tmp/sshd_config_new /etc/ssh/sshd_config
+  done
+  local svc=ssh
+  if is_rocky ; then svc="sshd" ; fi
+  systemctl reload "${svc}"
+}
 
 function prepare_to_install(){
-  nvsmi_works="0"
-  readonly bdcfg="/usr/local/bin/bdconfig"
-  download_dir=/tmp/
-  free_mem="$(awk '/^MemFree/ {print $2}' /proc/meminfo)"
-  # Write to a ramdisk instead of churning the persistent disk
-  if [[ ${free_mem} -ge 5250000 ]]; then
-    download_dir="/mnt/shm"
-    mkdir -p "${download_dir}"
-    mount -t tmpfs tmpfs "${download_dir}"
+  readonly uname_r=$(uname -r)
+  # Verify OS compatability and Secure boot state
+  check_os
+  check_secure_boot
 
-    # Download conda packages to tmpfs
-    /opt/conda/miniconda3/bin/conda config --add pkgs_dirs "${download_dir}"
-
-    # Download pip packages to tmpfs
-    pip config set global.cache-dir "${download_dir}" || echo "unable to set global.cache-dir"
-
-    # Download OS packages to tmpfs
-    if is_debuntu ; then
-      mount -t tmpfs tmpfs /var/cache/apt/archives
-    else
-      mount -t tmpfs tmpfs /var/cache/dnf
-    fi
+  # --- Detect Image Build Context ---
+  # Use 'initialization-actions' as the default name for clarity
+  INVOCATION_TYPE="$(get_metadata_attribute invocation-type "initialization-actions")"
+  if [[ "${INVOCATION_TYPE}" == "custom-images" ]]; then
+    IS_CUSTOM_IMAGE_BUILD="true"
+    # echo "Detected custom image build context (invocation-type=custom-images). Configuration will be deferred." # Keep silent
+  else
+    IS_CUSTOM_IMAGE_BUILD="false" # Ensure it's explicitly false otherwise
+    # echo "Running in initialization action mode (invocation-type=${INVOCATION_TYPE})." # Keep silent
   fi
-  install_log="${download_dir}/install.log"
+
+  # With the 402.0.0 release of gcloud sdk, `gcloud storage` can be
+  # used as a more performant replacement for `gsutil`
+  gsutil_cmd="gcloud storage"
+  gsutil_stat_cmd="gcloud storage objects describe"
+  gcloud_sdk_version="$(gcloud --version | awk -F'SDK ' '/Google Cloud SDK/ {print $2}')"
+  if version_lt "${gcloud_sdk_version}" "402.0.0" ; then
+    gsutil_cmd="gsutil -o GSUtil:check_hashes=never"
+    gsutil_stat_cmd="gsutil stat"
+  fi
+  curl_retry_args="-fsSL --retry-connrefused --retry 10 --retry-max-time 30"
+
+  # Setup temporary directories (potentially on RAM disk)
+  tmpdir=/tmp/ # Default
+  mount_ramdisk # Updates tmpdir if successful
+  install_log="${tmpdir}/install.log" # Set install log path based on final tmpdir
+
+  # Prepare GPU environment variables (versions, URLs, counts)
+  prepare_gpu_env
+
+  workdir=/opt/install-dpgce
+  # Set GCS bucket for caching
+  temp_bucket="$(get_metadata_attribute dataproc-temp-bucket)"
+  readonly temp_bucket
+  readonly pkg_bucket="gs://${temp_bucket}/dpgce-packages"
+  readonly bdcfg="/usr/local/bin/bdconfig"
+  export DEBIAN_FRONTEND=noninteractive
+
+  mkdir -p "${workdir}/complete"
+  trap exit_handler EXIT
+  set_proxy
+
+  is_complete prepare.common && return
+
+  harden_sshd_config
 
   if is_debuntu ; then
+    repair_old_backports
     clean_up_sources_lists
-    apt-get update -qq
+    apt-get update -qq --allow-releaseinfo-change
     apt-get -y clean
-    apt-get -y -qq autoremove
-    if is_debian12 ; then
+    apt-get -o DPkg::Lock::Timeout=60 -y autoremove
+    if ge_debian12 ; then
     apt-mark unhold systemd libsystemd0 ; fi
-  else
+    if is_ubuntu ; then
+      # Wait for gcloud to be available on Ubuntu
+      while ! command -v gcloud ; do sleep 5s ; done
+    fi
+  else # Rocky
     dnf clean all
   fi
 
-  # Clean conda cache
-  /opt/conda/miniconda3/bin/conda clean -a
+  # zero free disk space (only if creating image)
+  if [[ "${IS_CUSTOM_IMAGE_BUILD}" == "true" ]]; then ( set +e
+    time dd if=/dev/zero of=/zero status=none ; sync ; sleep 3s ; rm -f /zero
+  ) fi
 
-  # zero free disk space
-  if [[ -n "$(get_metadata_attribute creating-image)" ]]; then
-    set +e
-    time dd if=/dev/zero of=/zero ; sync ; rm -f /zero
-    set -e
-  fi
-
-  configure_dkms_certs
+  install_dependencies
 
   # Monitor disk usage in a screen session
-  if is_debuntu ; then
-      apt-get install -y -qq screen > /dev/null 2>&1
-  elif is_rocky ; then
-      dnf -y -q install screen > /dev/null 2>&1
-  fi
-  touch /tmp/keep-running-df
-  screen -d -m -US keep-running-df \
-    bash -c 'while [[ -f /tmp/keep-running-df ]] ; do df --si / | tee -a /tmp/disk-usage.log ; sleep 5s ; done'
+  df / > "/run/disk-usage.log"
+  touch "/run/keep-running-df"
+  screen -d -m -LUS keep-running-df \
+    bash -c "while [[ -f /run/keep-running-df ]] ; do df / | tee -a /run/disk-usage.log ; sleep 5s ; done"
+
+  mark_complete prepare.common
 }
 
-prepare_to_install
+function check_os() {
+  if is_debian && ( ! is_debian10 && ! is_debian11 && ! is_debian12 ) ; then
+      echo "Error: The Debian version ($(os_version)) is not supported. Please use a compatible Debian version."
+      exit 1
+  elif is_ubuntu && ( ! is_ubuntu18 && ! is_ubuntu20 && ! is_ubuntu22  ) ; then
+      echo "Error: The Ubuntu version ($(os_version)) is not supported. Please use a compatible Ubuntu version."
+      exit 1
+  elif is_rocky && ( ! is_rocky8 && ! is_rocky9 ) ; then
+      echo "Error: The Rocky Linux version ($(os_version)) is not supported. Please use a compatible Rocky Linux version."
+      exit 1
+  fi
 
-main
+  SPARK_VERSION="$(spark-submit --version 2>&1 | sed -n 's/.*version[[:blank:]]\+\([0-9]\+\.[0-9]\).*/\1/p' | head -n1)"
+  readonly SPARK_VERSION
+  if version_lt "${SPARK_VERSION}" "2.4" || \
+     version_ge "${SPARK_VERSION}" "4.0" ; then
+    echo "Error: Your Spark version (${SPARK_VERSION}) is not supported. Please use a supported version."
+    exit 1
+  fi
+
+  # Detect dataproc image version
+  if (! test -v DATAPROC_IMAGE_VERSION || [[ -z "${DATAPROC_IMAGE_VERSION}" ]]) ; then
+    if test -v DATAPROC_VERSION ; then
+      DATAPROC_IMAGE_VERSION="${DATAPROC_VERSION}"
+    else
+      # When building custom-images, neither of the above variables
+      # are defined and we need to make a reasonable guess
+      if   version_lt "${SPARK_VERSION}" "2.5" ; then DATAPROC_IMAGE_VERSION="1.5"
+      elif version_lt "${SPARK_VERSION}" "3.2" ; then DATAPROC_IMAGE_VERSION="2.0"
+      elif version_lt "${SPARK_VERSION}" "3.4" ; then DATAPROC_IMAGE_VERSION="2.1"
+      elif version_lt "${SPARK_VERSION}" "3.6" ; then
+        if [[ -f /etc/environment ]] ; then
+          eval "$(grep '^DATAPROC_IMAGE_VERSION' /etc/environment)" || DATAPROC_IMAGE_VERSION="2.2"
+        else
+          DATAPROC_IMAGE_VERSION="2.2"
+        fi
+      else DATAPROC_IMAGE_VERSION="2.3" ; fi # Default to latest known version
+    fi
+  fi
+}
+
+#
+# Generate repo file under /etc/apt/sources.list.d/
+#
+function apt_add_repo() {
+  local -r repo_name="$1"
+  local -r repo_data="$3" # "http(s)://host/path/uri argument0 .. argumentN"
+  local -r include_src="${4:-yes}"
+  local -r kr_path="${5:-/usr/share/keyrings/${repo_name}.gpg}"
+  local -r repo_path="${6:-/etc/apt/sources.list.d/${repo_name}.list}"
+
+  echo "deb [signed-by=${kr_path}] ${repo_data}" > "${repo_path}"
+  if [[ "${include_src}" == "yes" ]] ; then
+    echo "deb-src [signed-by=${kr_path}] ${repo_data}" >> "${repo_path}"
+  fi
+
+  apt-get update -qq
+}
+
+#
+# Generate repo file under /etc/yum.repos.d/
+#
+function dnf_add_repo() {
+  local -r repo_name="$1"
+  local -r repo_url="$3" # "http(s)://host/path/filename.repo"
+  local -r kr_path="${5:-/etc/pki/rpm-gpg/${repo_name}.gpg}"
+  local -r repo_path="${6:-/etc/yum.repos.d/${repo_name}.repo}"
+
+  curl ${curl_retry_args} "${repo_url}" \
+    | dd of="${repo_path}" status=progress
+}
+
+#
+# Keyrings default to
+# /usr/share/keyrings/${repo_name}.gpg (debian/ubuntu) or
+# /etc/pki/rpm-gpg/${repo_name}.gpg    (rocky/RHEL)
+#
+function os_add_repo() {
+  local -r repo_name="$1"
+  local -r signing_key_url="$2"
+  local -r repo_data="$3" # "http(s)://host/path/uri argument0 .. argumentN"
+  local kr_path
+  if is_debuntu ; then kr_path="${5:-/usr/share/keyrings/${repo_name}.gpg}"
+                  else kr_path="${5:-/etc/pki/rpm-gpg/${repo_name}.gpg}" ; fi
+
+  mkdir -p "$(dirname "${kr_path}")"
+
+  curl ${curl_retry_args} "${signing_key_url}" \
+    | gpg --import --no-default-keyring --keyring "${kr_path}"
+
+  if is_debuntu ; then apt_add_repo "${repo_name}" "${signing_key_url}" "${repo_data}" "${4:-yes}" "${kr_path}" "${6:-}"
+                  else dnf_add_repo "${repo_name}" "${signing_key_url}" "${repo_data}" "${4:-yes}" "${kr_path}" "${6:-}" ; fi
+}
+
+
+readonly _shortname="$(os_id)$(os_version|perl -pe 's/(\d+).*/$1/')"
+
+function install_spark_rapids() {
+  if [[ "${RAPIDS_RUNTIME}" != "SPARK" ]]; then return ; fi
+
+  # Update SPARK RAPIDS config
+  local DEFAULT_SPARK_RAPIDS_VERSION
+  DEFAULT_SPARK_RAPIDS_VERSION="24.08.1"
+  if version_ge "${DATAPROC_IMAGE_VERSION}" "2.2" ; then
+    DEFAULT_SPARK_RAPIDS_VERSION="25.02.1"
+  fi
+  local DEFAULT_XGBOOST_VERSION="1.7.6" # 2.1.3
+
+  # https://mvnrepository.com/artifact/ml.dmlc/xgboost4j-spark-gpu
+  local -r scala_ver="2.12"
+
+  if [[ "${DATAPROC_IMAGE_VERSION}" == "2.0" ]] ; then
+    DEFAULT_SPARK_RAPIDS_VERSION="23.08.2" # Final release to support spark 3.1.3
+  fi
+
+  readonly SPARK_RAPIDS_VERSION=$(get_metadata_attribute 'spark-rapids-version' ${DEFAULT_SPARK_RAPIDS_VERSION})
+  readonly XGBOOST_VERSION=$(get_metadata_attribute 'xgboost-version' ${DEFAULT_XGBOOST_VERSION})
+
+  local -r rapids_repo_url='https://repo1.maven.org/maven2/ai/rapids'
+  local -r nvidia_repo_url='https://repo1.maven.org/maven2/com/nvidia'
+  local -r dmlc_repo_url='https://repo.maven.apache.org/maven2/ml/dmlc'
+
+  local jar_basename
+  local spark_jars_dir="/usr/lib/spark/jars"
+  mkdir -p "${spark_jars_dir}"
+
+  jar_basename="xgboost4j-spark-gpu_${scala_ver}-${XGBOOST_VERSION}.jar"
+  cache_fetched_package "${dmlc_repo_url}/xgboost4j-spark-gpu_${scala_ver}/${XGBOOST_VERSION}/${jar_basename}" \
+                        "${pkg_bucket}/xgboost4j-spark-gpu_${scala_ver}/${XGBOOST_VERSION}/${jar_basename}" \
+                        "${spark_jars_dir}/${jar_basename}"
+
+  jar_basename="xgboost4j-gpu_${scala_ver}-${XGBOOST_VERSION}.jar"
+  cache_fetched_package "${dmlc_repo_url}/xgboost4j-gpu_${scala_ver}/${XGBOOST_VERSION}/${jar_basename}" \
+                        "${pkg_bucket}/xgboost4j-gpu_${scala_ver}/${XGBOOST_VERSION}/${jar_basename}" \
+                        "${spark_jars_dir}/${jar_basename}"
+
+  jar_basename="rapids-4-spark_${scala_ver}-${SPARK_RAPIDS_VERSION}.jar"
+  cache_fetched_package "${nvidia_repo_url}/rapids-4-spark_${scala_ver}/${SPARK_RAPIDS_VERSION}/${jar_basename}" \
+                        "${pkg_bucket}/rapids-4-spark_${scala_ver}/${SPARK_RAPIDS_VERSION}/${jar_basename}" \
+                        "${spark_jars_dir}/${jar_basename}"
+}
+
+# --- Script Entry Point ---
+prepare_to_install # Run preparation steps first
+main               # Call main logic

--- a/examples/secure-boot/pre-init.screenrc
+++ b/examples/secure-boot/pre-init.screenrc
@@ -4,20 +4,22 @@
 
 # screen -L -t monitor 0 /bin/bash
 
-#screen -L -t 1.5-debian10  1 /bin/bash -x examples/secure-boot/pre-init.sh 1.5-debian10
+#screen -L -t 1.5-debian10     1 /bin/bash -x examples/secure-boot/pre-init.sh 1.5-debian10
 
-screen -L -t 2.0-debian10  2 /bin/bash -x examples/secure-boot/pre-init.sh 2.0-debian10
-screen -L -t 2.0-rocky8    3 /bin/bash -x examples/secure-boot/pre-init.sh 2.0-rocky8
-screen -L -t 2.0-ubuntu18  4 /bin/bash -x examples/secure-boot/pre-init.sh 2.0-ubuntu18
+screen -L -t 2.0-debian10     2  /bin/bash -x examples/secure-boot/pre-init.sh 2.0-debian10
+screen -L -t 2.0-rocky8       3  /bin/bash -x examples/secure-boot/pre-init.sh 2.0-rocky8
+screen -L -t 2.0-ubuntu18     4  /bin/bash -x examples/secure-boot/pre-init.sh 2.0-ubuntu18
 
-screen -L -t 2.1-debian11  5 /bin/bash -x examples/secure-boot/pre-init.sh 2.1-debian11
-screen -L -t 2.1-rocky8    6 /bin/bash -x examples/secure-boot/pre-init.sh 2.1-rocky8
-screen -L -t 2.1-ubuntu20  7 /bin/bash -x examples/secure-boot/pre-init.sh 2.1-ubuntu20
+screen -L -t 2.1-debian11     5  /bin/bash -x examples/secure-boot/pre-init.sh 2.1-debian11
+screen -L -t 2.1-rocky8       6  /bin/bash -x examples/secure-boot/pre-init.sh 2.1-rocky8
+screen -L -t 2.1-ubuntu20     7  /bin/bash -x examples/secure-boot/pre-init.sh 2.1-ubuntu20
+#screen -L -t 2.1-ubuntu20-arm 11 /bin/bash -x examples/secure-boot/pre-init.sh 2.1-ubuntu20-arm
 
-screen -L -t 2.2-debian12  8 /bin/bash -x examples/secure-boot/pre-init.sh 2.2-debian12
-screen -L -t 2.2-rocky9    9 /bin/bash -x examples/secure-boot/pre-init.sh 2.2-rocky9
-screen -L -t 2.2-ubuntu22 10 /bin/bash -x examples/secure-boot/pre-init.sh 2.2-ubuntu22
+screen -L -t 2.2-debian12     8  /bin/bash -x examples/secure-boot/pre-init.sh 2.2-debian12
+screen -L -t 2.2-rocky9       9  /bin/bash -x examples/secure-boot/pre-init.sh 2.2-rocky9
+screen -L -t 2.2-ubuntu22     10 /bin/bash -x examples/secure-boot/pre-init.sh 2.2-ubuntu22
 
-screen -L -t 2.3-debian12 11 /bin/bash -x examples/secure-boot/pre-init.sh 2.3-debian12
-screen -L -t 2.3-rocky9   12 /bin/bash -x examples/secure-boot/pre-init.sh 2.3-rocky9
-screen -L -t 2.3-ubuntu22 13 /bin/bash -x examples/secure-boot/pre-init.sh 2.3-ubuntu22
+screen -L -t 2.3-debian12     12 /bin/bash -x examples/secure-boot/pre-init.sh 2.3-debian12
+screen -L -t 2.3-rocky9       13 /bin/bash -x examples/secure-boot/pre-init.sh 2.3-rocky9
+screen -L -t 2.3-ubuntu22     14 /bin/bash -x examples/secure-boot/pre-init.sh 2.3-ubuntu22
+#screen -L -t 2.3-ml-ubuntu22  15 /bin/bash -x examples/secure-boot/pre-init.sh 2.3-ml-ubuntu22

--- a/examples/secure-boot/pre-init.sh
+++ b/examples/secure-boot/pre-init.sh
@@ -16,6 +16,11 @@
 #
 # pre-init.sh <dataproc version>
 
+function version_ge(){ [[ "$1" = "$(echo -e "$1\n$2"|sort -V|tail -n1)" ]]; }
+function version_gt(){ [[ "$1" = "$2" ]]&& return 1 || version_ge "$1" "$2";}
+function version_le(){ [[ "$1" = "$(echo -e "$1\n$2"|sort -V|head -n1)" ]]; }
+function version_lt(){ [[ "$1" = "$2" ]]&& return 1 || version_le "$1" "$2";}
+
 set -e
 
 IMAGE_VERSION="$1"
@@ -41,11 +46,10 @@ gcloud config set account "${PRINCIPAL}"
 region="$(echo "${ZONE}" | perl -pe 's/-[a-z]+$//')"
 
 custom_image_zone="${ZONE}"
-disk_size_gb="30" # greater than or equal to 30
+disk_size_gb="30" # greater than or equal to 30 (32 for rocky8)
 
 SA_NAME="sa-${PURPOSE}"
 GSA="${SA_NAME}@${PROJECT_ID}.iam.gserviceaccount.com"
-
 
 # If no OS family specified, default to debian
 if [[ "${IMAGE_VERSION}" != *-* ]] ; then
@@ -62,27 +66,22 @@ fi
 
 CUDA_VERSION="12.4.1"
 case "${dataproc_version}" in
-  "1.5-debian10" ) CUDA_VERSION="11.5.2" ; short_dp_ver=1.5-deb10 ;;
-  "2.0-debian10" ) CUDA_VERSION="12.1.1" ; short_dp_ver=2.0-deb10 ;;
-  "2.0-rocky8"   ) CUDA_VERSION="12.1.1" ; short_dp_ver=2.0-roc8 ;;
-  "2.0-ubuntu18" ) CUDA_VERSION="12.1.1" ; short_dp_ver=2.0-ubu18 ;;
-  "2.1-debian11" ) CUDA_VERSION="12.4.1" ; short_dp_ver=2.1-deb11 ;;
-  "2.1-rocky8"   ) CUDA_VERSION="12.4.1" ; short_dp_ver=2.1-roc8 ;;
-  "2.1-ubuntu20" ) CUDA_VERSION="12.4.1" ; short_dp_ver=2.1-ubu20 ;;
-  "2.2-debian12" ) CUDA_VERSION="12.6.3" ; short_dp_ver=2.2-deb12 ;;
-  "2.2-rocky9"   ) CUDA_VERSION="12.6.3" ; short_dp_ver=2.2-roc9 ;;
-  "2.2-ubuntu22" ) CUDA_VERSION="12.6.3" ; short_dp_ver=2.2-ubu22 ;;
-  "2.3-debian12" ) CUDA_VERSION="12.6.3" ; short_dp_ver=2.3-deb12 ;;
-  "2.3-rocky9"   ) CUDA_VERSION="12.6.3" ; short_dp_ver=2.3-roc9 ;;
-  "2.3-ubuntu22" ) CUDA_VERSION="12.6.3" ; short_dp_ver=2.3-ubu22 ;;
+  "1.5-debian10"     ) CUDA_VERSION="11.5.2" ; short_dp_ver=1.5-deb10 ; disk_size_gb="20";;
+  "2.0-debian10"     ) CUDA_VERSION="12.1.1" ; short_dp_ver=2.0-deb10 ;;
+  "2.0-rocky8"       ) CUDA_VERSION="12.1.1" ; short_dp_ver=2.0-roc8 ; disk_size_gb="32";;
+  "2.0-ubuntu18"     ) CUDA_VERSION="12.1.1" ; short_dp_ver=2.0-ubu18 ;;
+  "2.1-debian11"     ) CUDA_VERSION="12.4.1" ; short_dp_ver=2.1-deb11 ;;
+  "2.1-rocky8"       ) CUDA_VERSION="12.4.1" ; short_dp_ver=2.1-roc8 ;;
+  "2.1-ubuntu20"     ) CUDA_VERSION="12.4.1" ; short_dp_ver=2.1-ubu20 ;;
+  "2.1-ubuntu20-arm" ) CUDA_VERSION="12.4.1" ; short_dp_ver=2.1-ubu20-arm ;;
+  "2.2-debian12"     ) CUDA_VERSION="12.6.3" ; short_dp_ver=2.2-deb12 ;;
+  "2.2-rocky9"       ) CUDA_VERSION="12.6.3" ; short_dp_ver=2.2-roc9 ;;
+  "2.2-ubuntu22"     ) CUDA_VERSION="12.6.3" ; short_dp_ver=2.2-ubu22 ;;
+  "2.3-debian12"     ) CUDA_VERSION="12.6.3" ; short_dp_ver=2.3-deb12 ;;
+  "2.3-rocky9"       ) CUDA_VERSION="12.6.3" ; short_dp_ver=2.3-roc9 ;;
+  "2.3-ubuntu22"     ) CUDA_VERSION="12.6.3" ; short_dp_ver=2.3-ubu22 ;;
+  "2.3-ml-ubuntu22"  ) CUDA_VERSION="12.6.3" ; short_dp_ver=2.3-ml-ubu22 ; disk_size_gb="50";;
 esac
-
-eval "$(bash examples/secure-boot/create-key-pair.sh)"
-metadata="rapids-runtime=SPARK"
-metadata="${metadata},cuda-version=${CUDA_VERSION}"
-metadata="${metadata},invocation-type=custom-images"
-metadata="${metadata},dataproc-temp-bucket=${TEMP_BUCKET}"
-metadata="${metadata},include-pytorch=1"
 
 function create_h100_instance() {
   python generate_custom_image.py \
@@ -100,9 +99,11 @@ function create_t4_instance() {
 
 function create_unaccelerated_instance() {
   python generate_custom_image.py \
-    --machine-type         "n1-standard-32" \
+    --machine-type         "n1-standard-2" \
     $*
 }
+
+OPTIONAL_COMPONENTS_ARG=""
 
 function generate() {
   local extra_args="$*"
@@ -115,6 +116,9 @@ function generate() {
     echo "Image already exists"
     return
   fi
+
+  local metadata="invocation-type=custom-images"
+  metadata="${metadata},dataproc-temp-bucket=${TEMP_BUCKET}"
 
   local install_image="$(jq -r ".[] | select(.name == \"${image_name}-install\").name" "${tmpdir}/images.json")"
   if [[ -n "${install_image}" ]] ; then
@@ -130,31 +134,73 @@ function generate() {
     gcloud -q compute instances delete "${image_name}-install"
   fi
 
-  create_function="create_t4_instance"
+  create_function="create_unaccelerated_instance"
 
-  if [[ "${customization_script}" =~ "cloud-sql-proxy.sh" \
-     || "${customization_script}" =~ "dask.sh" \
-     || "${customization_script}" =~ "no-customization.sh" ]] ; then
+  if [[ "${customization_script}" =~ "cloud-sql-proxy.sh"  ]] ; then
     metadata="${metadata},hive-metastore-instance=${PROJECT_ID}:${region}:${HIVE_NAME}"
     metadata="${metadata},db-hive-password-uri=${HIVEDB_PW_URI}"
     metadata="${metadata},kms-key-uri=${KMS_KEY_URI}"
-    create_function="create_unaccelerated_instance"
   fi
 
-  set -xe
-  "${create_function}" \
-    --image-name           "${image_name}" \
-    --customization-script "${customization_script}" \
-    --service-account      "${GSA}" \
-    --metadata             "${metadata}" \
-    --zone                 "${custom_image_zone}" \
-    --disk-size            "${disk_size_gb}" \
-    --gcs-bucket           "${BUCKET}" \
-    --subnet               "${SUBNET}" \
-    --optional-components  "DOCKER,PIG" \
-    --shutdown-instance-timer-sec=30 \
-    --no-smoke-test \
-    ${extra_args}
+  # For actions requiring access to the MOK during runtime, pass the requisite
+  # metadata to extract the signing material
+  if [[ "${customization_script}" =~ "install_gpu_driver.sh" ]] ; then
+    eval "$(bash examples/secure-boot/create-key-pair.sh)"
+    metadata="${metadata},public_secret_name=${public_secret_name}"
+    metadata="${metadata},private_secret_name=${private_secret_name}"
+    metadata="${metadata},secret_project=${secret_project}"
+    metadata="${metadata},secret_version=${secret_version}"
+    metadata="${metadata},modulus_md5sum=${modulus_md5sum}"
+  fi
+
+  if [[ "${customization_script}" =~ "install_gpu_driver.sh" ]] ; then
+    metadata="${metadata},cuda-version=${CUDA_VERSION}"
+    metadata="${metadata},include-pytorch=1"
+    create_function="create_t4_instance"
+  fi
+
+  if [[ "${customization_script}" =~ "spark-rapids.sh" ]] ; then
+    metadata="${metadata},rapids-runtime=SPARK"
+    create_function="create_t4_instance"
+  fi
+
+  if [[ "${customization_script}" =~ "rapids.sh" ]] ; then
+    metadata="${metadata},rapids-runtime=DASK"
+    create_function="create_t4_instance"
+  fi
+
+  # check for known retry-able errors after failed completion
+  local do_retry=1
+  set -x
+  while [[ "${do_retry}" == "1" ]]; do
+    do_retry=0
+    set +e
+    "${create_function}" \
+      --image-name           "${image_name}" \
+      --customization-script "${customization_script}" \
+      --service-account      "${GSA}" \
+      --metadata             "${metadata}" \
+      --zone                 "${custom_image_zone}" \
+      --disk-size            "${disk_size_gb}" \
+      --gcs-bucket           "${BUCKET}" \
+      --subnet               "${SUBNET}" \
+      ${OPTIONAL_COMPONENTS_ARG} \
+      --shutdown-instance-timer-sec=30 \
+      --no-smoke-test \
+      ${extra_args}
+    if [[ "$?" != "0" ]]; then
+      local img_build_dir="$(ls -d /tmp/custom-image-${image_name}-*)"
+      # retry if the startup-script.log file does not exist or is empty
+      local startup_script_log="${img_build_dir}/logs/startup-script.log"
+      if [[ ! -f "${startup_script_log}" ]] || [[ "$(wc -l < $startup-script.log)" == "0" ]]; then
+        do_retry=1
+        mkdir -p /tmp/old
+        mv "${img_build_dir}" /tmp/old
+      else
+        exit 1
+      fi
+    fi
+  done
   set +x
 }
 
@@ -163,55 +209,104 @@ function generate_from_dataproc_version() { generate --dataproc-version "$1" ; }
 function generate_from_prerelease_version() {
   # base image -> tensorflow
   local img_pfx="https://www.googleapis.com/compute/v1/projects/cloud-dataproc/global/images"
-  local src_timestamp="20250410-165100"
+#  local src_timestamp="20250410-165100"
+  local src_timestamp="20250505-045100"
   case "${dataproc_version}" in
-#    "1.5-debian10" ) image_uri="${img_pfx}/dataproc-1-5-deb10-${src_timestamp}-rc01"  ;;
-    "2.0-debian10" ) image_uri="${img_pfx}/dataproc-2-0-deb10-${src_timestamp}-rc01"  ;;
-    "2.0-rocky8"   ) image_uri="${img_pfx}/dataproc-2-0-roc8-${src_timestamp}-rc01"   ;;
-    "2.0-ubuntu18" ) image_uri="${img_pfx}/dataproc-2-0-ubu18-${src_timestamp}-rc01"  ;;
-    "2.1-debian11" ) image_uri="${img_pfx}/dataproc-2-1-deb11-${src_timestamp}-rc01"  ;;
-    "2.1-rocky8"   ) image_uri="${img_pfx}/dataproc-2-1-roc8-${src_timestamp}-rc01"   ;;
-    "2.1-ubuntu20" ) image_uri="${img_pfx}/dataproc-2-1-ubu20-${src_timestamp}-rc01"  ;;
-    "2.2-debian12" ) image_uri="${img_pfx}/dataproc-2-2-deb12-${src_timestamp}-rc01"  ;;
-    "2.2-rocky9"   ) image_uri="${img_pfx}/dataproc-2-2-roc9-${src_timestamp}-rc01"   ;;
-    "2.2-ubuntu22" ) image_uri="${img_pfx}/dataproc-2-2-ubu22-${src_timestamp}-rc01"  ;;
-    "2.3-debian12" ) image_uri="${img_pfx}/dataproc-2-3-deb12-${src_timestamp}-rc01"  ;;
-    "2.3-rocky9"   ) image_uri="${img_pfx}/dataproc-2-3-roc9-${src_timestamp}-rc01"   ;;
-    "2.3-ubuntu22" ) image_uri="${img_pfx}/dataproc-2-3-ubu22-${src_timestamp}-rc01"  ;;
+#    "1.5-debian10"     ) image_uri="${img_pfx}/dataproc-1-5-deb10-${src_timestamp}-rc01"  ;;
+#    "1.5-debian10"     ) image_uri="${img_pfx}/dataproc-1-5-deb10-20200820-160220-rc01"  ;;
+#    "1.5-debian10"     ) image_uri="https://www.googleapis.com/compute/v1/projects/cloud-dataproc-ci/global/images/dataproc-1-5-deb10-20230909-165100-rc01" ;;
+    "1.5-debian10"     ) image_uri="https://www.googleapis.com/compute/v1/projects/cloud-dataproc/global/images/dataproc-1-5-deb10-20230909-165100-rc01" ;;
+    "2.0-debian10"     ) image_uri="${img_pfx}/dataproc-2-0-deb10-${src_timestamp}-rc01"  ;;
+    "2.0-rocky8"       ) image_uri="${img_pfx}/dataproc-2-0-roc8-${src_timestamp}-rc01"   ;;
+    "2.0-ubuntu18"     ) image_uri="${img_pfx}/dataproc-2-0-ubu18-${src_timestamp}-rc01"  ;;
+    "2.1-debian11"     ) image_uri="${img_pfx}/dataproc-2-1-deb11-${src_timestamp}-rc01"  ;;
+    "2.1-rocky8"       ) image_uri="${img_pfx}/dataproc-2-1-roc8-${src_timestamp}-rc01"   ;;
+    "2.1-ubuntu20"     ) image_uri="${img_pfx}/dataproc-2-1-ubu20-${src_timestamp}-rc01"  ;;
+    "2.1-ubuntu20-arm" ) image_uri="${img_pfx}/dataproc-2-1-ubu20-arm-${src_timestamp}-rc01"  ;;
+    "2.2-debian12"     ) image_uri="${img_pfx}/dataproc-2-2-deb12-${src_timestamp}-rc01"  ;;
+    "2.2-rocky9"       ) image_uri="${img_pfx}/dataproc-2-2-roc9-${src_timestamp}-rc01"   ;;
+    "2.2-ubuntu22"     ) image_uri="${img_pfx}/dataproc-2-2-ubu22-${src_timestamp}-rc01"  ;;
+    "2.3-debian12"     ) image_uri="${img_pfx}/dataproc-2-3-deb12-${src_timestamp}-rc01"  ;;
+    "2.3-rocky9"       ) image_uri="${img_pfx}/dataproc-2-3-roc9-${src_timestamp}-rc01"   ;;
+    "2.3-ubuntu22"     ) image_uri="${img_pfx}/dataproc-2-3-ubu22-${src_timestamp}-rc01"  ;;
+    "2.3-ml-ubuntu22"  ) image_uri="${img_pfx}/dataproc-2-3-ml-ubu22-${src_timestamp}-rc01"  ;;
   esac
   generate --base-image-uri "${image_uri}"
 }
 
 function generate_from_base_purpose() {
-  generate --base-image-uri "https://www.googleapis.com/compute/v1/projects/${PROJECT_ID}/global/images/${1}-${dataproc_version/\./-}-${timestamp}"
+#  local image_name="dataproc-${short_dp_ver//\./-}-${timestamp}-${PURPOSE}"
+# https://pantheon.corp.google.com/compute/imagesDetail/projects/cloud-dataproc-ci/global/images/dataproc-2-0-deb10-20250422-193049-secure-boot?project=cloud-dataproc-ci
+# https://www.googleapis.com/compute/v1/projects/dataproc-cloud-dataproc-ci/global/images/dataproc-2-0-deb10-20250422-193049-secure-boot
+# https://www.googleapis.com/compute/v1/projects/cloud-dataproc-ci/global/images/dataproc-2-0-deb10-20250422-193049-secure-bootprojects/dataproc-${PROJECT_ID}/global/images"
+#  local img_pfx="https://www.googleapis.com/compute/v1/projects/dataproc-${PROJECT_ID}/global/images"
+  local img_pfx="https://www.googleapis.com/compute/v1/projects/${PROJECT_ID}/global/images"
+  generate --base-image-uri "${img_pfx}/dataproc-${short_dp_ver/\./-}-${timestamp}-${1}"
+#  generate --base-image-uri "${img_pfx}/${1}-${dataproc_version/\./-}-${timestamp}"
 }
 
-# base image -> tensorflow
-disk_size_gb="42"
-case "${dataproc_version}" in
-  "1.5-debian10" ) disk_size_gb="42" ;; #
-  "2.0-debian10" ) disk_size_gb="42" ;; #  41.11G  36.28G     3.04G  93% / # tf-pre-init
-  "2.0-rocky8"   ) disk_size_gb="45" ;; #  44.79G  38.43G     6.36G  86% / # tf-pre-init
-  "2.0-ubuntu18" ) disk_size_gb="41" ;; #  39.55G  35.39G     4.14G  90% / # tf-pre-init
-  "2.1-debian11" ) disk_size_gb="46" ;; #  45.04G  39.31G     3.78G  92% / # tf-pre-init
-  "2.1-rocky8"   ) disk_size_gb="48" ;; #  48.79G  41.73G     7.06G  86% / # tf-pre-init
-  "2.1-ubuntu20" ) disk_size_gb="46" ;; #  44.40G  39.92G     4.46G  90% / # tf-pre-init
-  "2.2-debian12" ) disk_size_gb="47" ;; #  46.03G  40.76G     3.28G  93% / # tf-pre-init
-  "2.2-rocky9"   ) disk_size_gb="47" ;; #  46.79G  40.86G     5.93G  88% / # tf-pre-init
-  "2.2-ubuntu22" ) disk_size_gb="47" ;; #  45.37G  40.56G     4.79G  90% / # tf-pre-init
-  "2.3-debian12" ) disk_size_gb="42" ;;
-  "2.3-rocky9"   ) disk_size_gb="42" ;;
-  "2.3-ubuntu22" ) disk_size_gb="42" ;;
-esac
-
-#disk_size_gb="60" # greater than or equal to 40
+# base image -> secure-boot
 
 # Install secure-boot certs without customization
 PURPOSE="secure-boot"
 customization_script="examples/secure-boot/no-customization.sh"
-#time generate_from_dataproc_version "${dataproc_version}"
+time generate_from_dataproc_version "${dataproc_version}"
 
-time generate_from_prerelease_version "${dataproc_version}"
+#time generate_from_prerelease_version "${dataproc_version}"
+
+if version_ge "${IMAGE_VERSION}" "2.3" ; then
+
+  ## run the installer for the DOCKER optional component
+  PURPOSE="docker"
+  OPTIONAL_COMPONENTS_ARG='--optional-components=DOCKER'
+  customization_script="examples/secure-boot/no-customization.sh"
+  time generate_from_base_purpose "secure-boot"
+
+  ## run the installer for the ZEPPELIN optional component
+  PURPOSE="zeppelin"
+  OPTIONAL_COMPONENTS_ARG='--optional-components=ZEPPELIN'
+  customization_script="examples/secure-boot/no-customization.sh"
+  time generate_from_base_purpose "secure-boot"
+
+  ## run the installer for the DOCKER,PIG optional components
+  PURPOSE="docker-pig"
+  OPTIONAL_COMPONENTS_ARG='--optional-components=PIG'
+  customization_script="examples/secure-boot/no-customization.sh"
+  time generate_from_base_purpose "docker"
+
+fi
+
+OPTIONAL_COMPONENTS_ARG=""
+
+## Execute spark-rapids/spark-rapids.sh init action on base image
+PURPOSE="cloud-sql-proxy"
+customization_script="examples/secure-boot/cloud-sql-proxy.sh"
+echo time generate_from_base_purpose "secure-boot"
+
+# secure-boot -> tensorflow
+
+case "${dataproc_version}" in
+# DP_IMG_VER       RECOMMENDED_DISK_SIZE   DSK_SZ  D_USED   D_FREE  D%F     DATE_SAMPLED
+
+  "2.0-debian10"     ) disk_size_gb="36" ;; #  35.20G  30.74G    2.91G  92% / # 20250507-083009-tf
+  "2.0-rocky8"       ) disk_size_gb="43" ;; #  48.79G  36.34G   12.45G  75% / # 20250507-083009-tf
+  "2.0-ubuntu18"     ) disk_size_gb="38" ;; #  36.65G  32.24G    4.39G  89% / # 20250507-083009-tf
+
+  "2.1-debian11"     ) disk_size_gb="42" ;; #  41.11G  35.82G    3.50G  92% / # 20250507-083009-tf
+  "2.1-rocky8"       ) disk_size_gb="45" ;; #  59.79G  38.41G   21.39G  65% / # 20250429-193537-tf
+  "2.1-ubuntu20"     ) disk_size_gb="42" ;; #  47.31G  36.02G   11.27G  77% / # 20250507-083009-tf
+  "2.1-ubuntu20-arm" ) disk_size_gb="45" ;; # 39.55G 39.39G   0.15G 100% / # pre-init-2-1-ubuntu20
+
+  "2.2-debian12"     ) disk_size_gb="51" ;; #  58.82G  43.88G   12.44G  78% / # 20250429-193537-tf
+  "2.2-rocky9"       ) disk_size_gb="51" ;; #  49.79G  43.51G    6.28G  88% / # 20250429-193537-tf
+  "2.2-ubuntu22"     ) disk_size_gb="50" ;; #  48.28G  43.32G    4.94G  90% / # 20250429-193537-tf
+
+  "2.3-debian12"     ) disk_size_gb="42" ;; #  41.11G  36.20G    3.12G  93% / # 20250507-083009-tf
+  "2.3-rocky9"       ) disk_size_gb="44" ;; #  49.79G  37.82G   11.98G  76% / # 20250507-083009-tf
+  "2.3-ubuntu22"     ) disk_size_gb="42" ;; #  40.52G  36.18G    4.33G  90% / # 20250507-083009-tf
+  "2.3-ml-ubuntu22"  ) disk_size_gb="70" ;; #  40.52G  36.18G    4.33G  90% / # 20250507-083009-tf
+
+esac
 
 # Install GPU drivers + cuda + rapids + cuDNN + nccl + tensorflow + pytorch on dataproc base image
 PURPOSE="tf"
@@ -221,19 +316,14 @@ time generate_from_base_purpose "secure-boot"
 ## Execute spark-rapids/spark-rapids.sh init action on base image
 PURPOSE="spark"
 customization_script="examples/secure-boot/spark-rapids.sh"
-echo time generate_from_base_purpose "tf"
-
-## Execute spark-rapids/spark-rapids.sh init action on base image
-PURPOSE="cloud-sql-proxy"
-customization_script="examples/secure-boot/cloud-sql-proxy.sh"
-time generate_from_base_purpose "secure-boot"
+time generate_from_base_purpose "tf"
 
 ## Execute spark-rapids/mig.sh init action on base image
 PURPOSE="mig-pre-init"
 customization_script="examples/secure-boot/mig.sh"
 echo time generate_from_base_purpose "tf"
 
-# cuda image -> rapids
+# tf image -> rapids
 case "${dataproc_version}" in
   "2.0-debian10" ) disk_size_gb="41" ;; # 40.12G 37.51G   0.86G  98% / # rapids-pre-init-2-0-debian10
   "2.0-rocky8"   ) disk_size_gb="41" ;; # 38.79G 38.04G   0.76G  99% / # rapids-pre-init-2-0-rocky8
@@ -241,6 +331,7 @@ case "${dataproc_version}" in
   "2.1-debian11" ) disk_size_gb="44" ;; # 42.09G 39.77G   0.49G  99% / # rapids-pre-init-2-1-debian11
   "2.1-rocky8"   ) disk_size_gb="44" ;; # 43.79G 41.11G   2.68G  94% / # rapids-pre-init-2-1-rocky8
   "2.1-ubuntu20" ) disk_size_gb="45" ;; # 39.55G 39.39G   0.15G 100% / # rapids-pre-init-2-1-ubuntu20
+  "2.1-ubuntu20-arm" ) disk_size_gb="45" ;; # 39.55G 39.39G   0.15G 100% / # pre-init-2-1-ubuntu20
   "2.2-debian12" ) disk_size_gb="46" ;; # 44.06G 41.73G   0.41G 100% / # rapids-pre-init-2-2-debian12
   "2.2-rocky9"   ) disk_size_gb="45" ;; # 44.79G 42.29G   2.51G  95% / # rapids-pre-init-2-2-rocky9
   "2.2-ubuntu22" ) disk_size_gb="46" ;; # 42.46G 41.97G   0.48G  99% / # rapids-pre-init-2-2-ubuntu22
@@ -249,31 +340,37 @@ esac
 #disk_size_gb="45"
 
 # Install dask with rapids on base image
-PURPOSE="rapids-pre-init"
+PURPOSE="rapids"
 customization_script="examples/secure-boot/rapids.sh"
-time generate_from_base_purpose "tf-pre-init"
+echo time generate_from_base_purpose "tf"
 #time generate_from_base_purpose "cuda-pre-init"
 
 ## Install dask without rapids on base image
-PURPOSE="dask-pre-init"
+PURPOSE="dask"
 customization_script="examples/secure-boot/dask.sh"
-time generate_from_base_purpose "secure-boot"
+echo time generate_from_base_purpose "secure-boot"
 #time generate_from_base_purpose "cuda-pre-init"
 
 # cuda image -> pytorch
 case "${dataproc_version}" in
-  "2.0-debian10" ) disk_size_gb="44" ;; # 40.12G 37.51G   0.86G  98% / # pre-init-2-0-debian10
-  "2.0-rocky8"   ) disk_size_gb="41" ;; # 38.79G 38.04G   0.76G  99% / # pre-init-2-0-rocky8
-  "2.0-ubuntu18" ) disk_size_gb="44" ;; # 37.62G 36.69G   0.91G  98% / # pre-init-2-0-ubuntu18
-  "2.1-debian11" ) disk_size_gb="44" ;; # 42.09G 39.77G   0.49G  99% / # pre-init-2-1-debian11
-  "2.1-rocky8"   ) disk_size_gb="44" ;; # 43.79G 41.11G   2.68G  94% / # pre-init-2-1-rocky8
-  "2.1-ubuntu20" ) disk_size_gb="45" ;; # 39.55G 39.39G   0.15G 100% / # pre-init-2-1-ubuntu20
-  "2.2-debian12" ) disk_size_gb="48" ;; # 44.06G 41.73G   0.41G 100% / # pre-init-2-2-debian12
-  "2.2-rocky9"   ) disk_size_gb="45" ;; # 44.79G 42.29G   2.51G  95% / # pre-init-2-2-rocky9
-  "2.2-ubuntu22" ) disk_size_gb="46" ;; # 42.46G 41.97G   0.48G  99% / # pre-init-2-2-ubuntu22
+  "2.0-debian10"     ) disk_size_gb="44" ;; # 40.12G 37.51G   0.86G  98% / # pre-init-2-0-debian10
+  "2.0-rocky8"       ) disk_size_gb="41" ;; # 38.79G 38.04G   0.76G  99% / # pre-init-2-0-rocky8
+  "2.0-ubuntu18"     ) disk_size_gb="44" ;; # 37.62G 36.69G   0.91G  98% / # pre-init-2-0-ubuntu18
+  "2.1-debian11"     ) disk_size_gb="44" ;; # 42.09G 39.77G   0.49G  99% / # pre-init-2-1-debian11
+  "2.1-rocky8"       ) disk_size_gb="44" ;; # 43.79G 41.11G   2.68G  94% / # pre-init-2-1-rocky8
+  "2.1-ubuntu20"     ) disk_size_gb="45" ;; # 39.55G 39.39G   0.15G 100% / # pre-init-2-1-ubuntu20
+  "2.1-ubuntu20-arm" ) disk_size_gb="45" ;; # 39.55G 39.39G   0.15G 100% / # pre-init-2-1-ubuntu20
+  "2.2-debian12"     ) disk_size_gb="48" ;; # 44.06G 41.73G   0.41G 100% / # pre-init-2-2-debian12
+  "2.2-rocky9"       ) disk_size_gb="48" ;; # 44.79G 42.29G   2.51G  95% / # pre-init-2-2-rocky9
+  "2.2-ubuntu22"     ) disk_size_gb="46" ;; # 42.46G 41.97G   0.48G  99% / # pre-init-2-2-ubuntu22
+  "2.3-debian12"     ) disk_size_gb="42" ;; # 41.11G 36.20G   3.12G  93% / # 20250507-083009-tf
+  "2.3-rocky9"       ) disk_size_gb="44" ;; # 49.79G 37.82G  11.98G  76% / # 20250507-083009-tf
+  "2.3-ubuntu22"     ) disk_size_gb="42" ;; # 40.52G 36.18G   4.33G  90% / # 20250507-083009-tf
+  "2.3-ml-ubuntu22"  ) disk_size_gb="60" ;; # 40.52G 36.18G   4.33G  90% / # 20250507-083009-tf
 esac
 
 ## Install pytorch on base image
-PURPOSE="pytorch-pre-init"
+PURPOSE="pytorch"
 customization_script="examples/secure-boot/pytorch.sh"
-#time generate_from_base_purpose "cuda-pre-init"
+echo time generate_from_base_purpose "tf"
+


### PR DESCRIPTION
This PR resolves issue #110  where GPU parameters were not correctly applied to Spark configurations during Dataproc custom image creation. The core problem was that Spark configuration files (e.g., `/etc/spark/conf/spark-defaults.conf`) are typically created by Dataproc's internal initialization processes *after* the image customization script (like `install_gpu_driver.sh`) has already run.

The main fix is implemented in `install_gpu_driver.sh` through a deferred configuration mechanism, which is enabled when the script detects it's running in an image build context. This detection is facilitated by changes in the image generation orchestrator script (`examples/secure-boot/pre-init.sh`).

**Core Issue Resolution in `install_gpu_driver.sh`:**

1.  **Detection of Image Build Context:**
    * The `install_gpu_driver.sh` script now checks for a metadata attribute `invocation-type` during its `prepare_to_install` phase.
    * If `invocation-type` is set to `"custom-images"`, a shell variable `IS_CUSTOM_IMAGE_BUILD` is set to `true`, indicating the script is running during a custom image build.

2.  **Deferred Configuration Script Generation and Conditional Execution:**
    * The function `create_deferred_config_files` is now called unconditionally in the `main` execution flow. This function is responsible for generating:
        * A new standalone script: `/usr/local/sbin/apply-dataproc-gpu-config.sh`. This script bundles the necessary functions (copied using `declare -p`) and logic (primarily the `run_hadoop_spark_config` function) to perform Hadoop and Spark configurations. This includes setting YARN properties and, crucially, updating `/etc/spark/conf.dist/spark-defaults.conf` with GPU discovery scripts and RAPIDS properties.
        * A systemd service file: `/etc/systemd/system/dataproc-gpu-config.service`. This is a `oneshot` service designed to execute `/usr/local/sbin/apply-dataproc-gpu-config.sh`.
    * The value of `IS_CUSTOM_IMAGE_BUILD` then dictates how this generated script is handled:
        * If `IS_CUSTOM_IMAGE_BUILD` is `true` (during image creation): The `dataproc-gpu-config.service` is enabled. This ensures `/usr/local/sbin/apply-dataproc-gpu-config.sh` runs on the *first boot* of a VM created from the custom image, after Dataproc agent and YARN services are likely initialized and configuration files are present.
        * If `IS_CUSTOM_IMAGE_BUILD` is `false` (running as a standard initialization action): The generated `/usr/local/sbin/apply-dataproc-gpu-config.sh` script is executed immediately by the main `install_gpu_driver.sh` script.

3.  **First Boot Execution and Cleanup (for Custom Images):**
    * When a VM instance is launched from the custom image, the `dataproc-gpu-config.service` executes the `/usr/local/sbin/apply-dataproc-gpu-config.sh` script.
    * This script then applies all the necessary Spark and YARN configurations.
    * Upon successful completion, the `apply-dataproc-gpu-config.sh` script disables its own systemd service and removes both the service file and itself, ensuring it only runs once per instance.

This approach ensures that Spark configuration modifications are reliably applied after the base Spark configuration files are in place, resolving the timing issue encountered during custom image builds, while maintaining correct behavior for standard init actions.

**Supporting Changes in Image Generation Scripts:**

* **`examples/secure-boot/pre-init.sh`:**
    * This script, which orchestrates custom image creation using `generate_custom_image.py`, has been updated to pass the crucial metadata `invocation-type=custom-images` to the image generation process. This enables `install_gpu_driver.sh` to correctly identify the image build context and trigger the deferred configuration logic.
    * The script also includes updated logic for sequencing image builds and managing metadata (like CUDA versions, secure boot keys, etc.) for different test scenarios.

**Other Notable Changes in `install_gpu_driver.sh`:**

* **Comprehensive OS and Version Handling:** Refactored OS detection and version comparison; improved logic for determining default CUDA/Driver/cuDNN/NCCL versions based on Dataproc image version and metadata attributes.
* **GCS Caching for Dependencies:** Implemented robust GCS caching for NVIDIA drivers, CUDA runfiles, cuDNN, NCCL builds, kernel modules, Conda environments (e.g., for PyTorch), and Spark RAPIDS JARs to accelerate builds and init actions.
* **Refactored Installation Logic:** Modularized installation steps for various components.
* **Secure Boot & DKMS:** Improved handling of DKMS signing certificate configuration.
* **Configuration Script (`configure_gpu_script`):** The generated GPU discovery script (`getGpusResources.sh`) is simplified. Spark properties for RAPIDS and GPU resource allocation are now reliably added to `spark-defaults.conf` via the deferred mechanism.
* **Repository and Keyring Management:** Enhanced robustness for APT/YUM repository and GPG keyring management with new helper functions.
* **Exit Handler & Preparation:** More comprehensive cleanup in `exit_handler`; centralized setup in `prepare_to_install`, including `sshd` hardening.
* **Spark RAPIDS & PyTorch Installation:** New functions to install Spark RAPIDS JARs and optionally PyTorch, integrated with the GCS caching mechanism.

Changes in `examples/secure-boot/build-current-images.sh` and `examples/secure-boot/pre-init.screenrc` are primarily related to test orchestration and logging improvements for the image build process and are not direct functional parts of this core fix.