### PR TITLE
Avoid matching `2.3-ubuntu22-arm` labels for `2.3-ubuntu22`

### DIFF
--- a/custom_image_utils/args_inferer.py
+++ b/custom_image_utils/args_inferer.py
@@ -135,7 +135,7 @@ def _get_dataproc_image_path_by_version(version):
     # expand it to 1-5-\d+-debian10 so we can do a regexp on the minor version
     minor_version = parsed_version[1].split("-")[0]
     parsed_version[1] = parsed_version[1].replace("-", "-\d+-")
-    filter_arg = ("labels.goog-dataproc-version ~ ^{}-{} AND NOT name ~ -eap$"
+    filter_arg = ("labels.goog-dataproc-version ~ ^{}-{}$ AND NOT name ~ -eap$"
                   " AND status = READY").format(parsed_version[0],
                                                 parsed_version[1])
   else:


### PR DESCRIPTION
### Problem
1. When `--dataproc_version=2.3-ubuntu22` is provided following query to filter images is used.
    ```
    gcloud compute images list --project=cloud-dataproc --filter="labels.goog-dataproc-version ~ ^2-3-\d+-ubuntu22 AND status = READY" --format "csv[no-heading=true](name,labels.goog-dataproc-version)" --sort-by=~creationTimestamp
    ```
2. If the listed ARM image is the first one (due to its latest creation time stamp) then that image will be selected as a base image.
3. Custom image VM will not boot because boot disk and machine types dont match.

### Solution
Match the exact os version suffix. For ex: Use `^2-3-\d+-ubuntu22$` instead of `^2-3-\d+-ubuntu22` in the filter with regex.